### PR TITLE
WIP: *.pm: add vim modeline, fix whitespaces

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,3 +18,5 @@ WriteMakefile(
                         },
    TESTS             => '*/*.t',
 );
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/Dimension.pm
+++ b/lib/Bagger/Storage/Dimension.pm
@@ -9,7 +9,7 @@ package Bagger::Storage::Dimension;
 =head1 SYNOPSIS
 
    my $dimension = Bagger::Storage::Dimension->new(
-           { fieldname   => 'service', 
+           { fieldname   => 'service',
              ordinality  => 1,
              default_val => 'none'
           });
@@ -27,7 +27,7 @@ with 'Bagger::Storage::PGObject';
 
 =head1 DESCRIPTION
 
-Dimensions represent the dimension partitions for Bagger tables.  Each 
+Dimensions represent the dimension partitions for Bagger tables.  Each
 dimension is extracted from the incoming JSON document in order and this
 information is used to write the document to the correct table.  The current
 routines have provisions for default values although it is not clear if these
@@ -89,3 +89,5 @@ Note that the database will refuse to append the same fieldname more than once.
 dbmethod append => (funcname => 'append_dimension', returns_objects => 1);
 
 1;
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/Index.pm
+++ b/lib/Bagger/Storage/Index.pm
@@ -92,7 +92,7 @@ sub supported_index_ams { @index_ams };
 sub remove_index_am {
     my $self = shift;
     my $am = lc(shift // $self); # handle :: and -> syntax
-    @index_ams = grep { $_ ne $am } @index_ams; 
+    @index_ams = grep { $_ ne $am } @index_ams;
 }
 
 sub add_index_am {
@@ -146,18 +146,18 @@ read-only.  What is read-only is the reference assignment.
 
 =cut
 
-sub _get_fields { 
+sub _get_fields {
     my $self = shift;
     return [] unless $self->id;
     return [Bagger::Storage::Index::Field->list($self->id)];
 }
 
 has fields => (
-              is      => 'ro', 
+              is      => 'ro',
               isa     => 'ArrayRef[Bagger::Index::Fields]',
-	      lazy    => 1,
+              lazy    => 1,
               builder => '_get_fields',
-	      required => 0,
+              required => 0,
 );
 
 
@@ -165,7 +165,7 @@ has fields => (
 
 =head2 $index = Bagger::Storage::Index->get(index_name) - get by index name
 
-This returns the index from the database.  Note the fields are only lazily 
+This returns the index from the database.  Note the fields are only lazily
 retrieved.
 
 =cut
@@ -212,9 +212,9 @@ have already been added.
 sub next_ordinal {
     my ($self) = @_;
     return 0 unless defined $self->fields and @{$self->fields};
-    my ($max_ordinal) = 
-		   sort { $b->ordinality <=> $a->ordinality }
-		   @{$self->fields};
+    my ($max_ordinal) =
+                  sort { $b->ordinality <=> $a->ordinality }
+                  @{$self->fields};
     return $max_ordinal->ordinality + 1;
 }
 
@@ -232,22 +232,23 @@ sub create_statement {
     croak 'Must supply a schema_name to create_statement' unless $schema_name;
     croak 'Must supply a table_name to create_statement' unless $table_name;
     croak "Index must have fields added first" unless $self->next_ordinal;
-    
+
     my $idx_name    = $self->_dbh->quote_identifier(
                       $table_name . '_' . $self->indexname);
     $schema_name = $self->_dbh->quote_identifier($schema_name);
     $table_name  = $self->_dbh->quote_identifier($table_name);
 
-    my $field_str   = join ',', 
+    my $field_str   = join ',',
                    map { "($_)" } # indexes require this extra paren set
-		   sort { $a->ordinality <=> $b->ordinality }
-		   @{$self->fields};
+                   sort { $a->ordinality <=> $b->ordinality }
+                   @{$self->fields};
 
     my $stmt =  "CREATE INDEX $idx_name ON $schema_name.$table_name ".
            "($field_str) using " . $self->access_method;
     $stmt .= " TABLESPACE " .
-	   $self->_dbh->quote_identifier($self->tablespc) if $self->tablespc;
-	  
+           $self->_dbh->quote_identifier($self->tablespc) if $self->tablespc;
 }
 
 1;
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/Index/Field.pm
+++ b/lib/Bagger/Storage/Index/Field.pm
@@ -142,7 +142,7 @@ Returns a list of index fields for the given index id.
 sub list {
     my ($self, $index_id) = @_;
     return map { __PACKAGE__->new($_) }
-          $self->call_procedure(funcname => 'list_index_fields', 
+          $self->call_procedure(funcname => 'list_index_fields',
                                     args => [$index_id]);
 
 }
@@ -152,3 +152,5 @@ sub list {
 =cut
 
 1;
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/Instance.pm
+++ b/lib/Bagger/Storage/Instance.pm
@@ -77,7 +77,7 @@ has host => (is => 'ro', isa => 'Str', required => 1);
 
 =head2 port
 
-An integer representation of the database port. Required.  By default set to 
+An integer representation of the database port. Required.  By default set to
 5432.
 
 =cut
@@ -110,22 +110,22 @@ the status.
 
 has can_read => (is => 'ro', isa => 'Bool', lazy => 1, builder => '_can_read');
 
-sub _can_read { 
+sub _can_read {
     my ($self) = @_;
     return bool($self->status & F_READ);
 }
 
 =head2 can_write
 
-This indicates whether the node can ingest data.  This is generated from 
+This indicates whether the node can ingest data.  This is generated from
 status.
 
 =cut
 
-has can_write => (is => 'ro', isa => 'Bool', lazy => 1, 
+has can_write => (is => 'ro', isa => 'Bool', lazy => 1,
                   builder => '_can_write');
 
-sub _can_write { 
+sub _can_write {
     my ($self)  = @_;
     return bool($self->status & F_WRITE);
 }
@@ -134,7 +134,7 @@ sub _can_write {
 
 =head2 register
 
-This saves the object in the database and returns a new object with status and 
+This saves the object in the database and returns a new object with status and
 id set by the database.  Use as follows:
 
    $instance = $instance->register();
@@ -171,7 +171,7 @@ sub get_by_info {
     my ($self, $host, $port) = @_;
     my ($result) = __PACKAGE__->call_procedure(
                      funcname => 'get_pg_instance_by_host_and_port',
-		     args     => [$host, $port]
+                     args     => [$host, $port]
     );
     return __PACKAGE__->new($result);
 }
@@ -184,7 +184,7 @@ This sets the instance status and returns a new object.
 
 sub set_status {
     my ($self, $status) = @_;
-    my ($result) = $self->call_dbmethod(funcname => 'set_pg_instance_status', 
+    my ($result) = $self->call_dbmethod(funcname => 'set_pg_instance_status',
             args => {status => $status});
     return __PACKAGE__->new($result);
 }
@@ -206,3 +206,5 @@ sub list {
 =cut
 
 1;
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/LenkwerkSetup.pm
+++ b/lib/Bagger/Storage/LenkwerkSetup.pm
@@ -156,3 +156,5 @@ sub set_dbpass {
 }
 
 1;
+
+# vim:ts=4:sw=4:expandtab

--- a/lib/Bagger/Storage/PGObject.pm
+++ b/lib/Bagger/Storage/PGObject.pm
@@ -13,7 +13,7 @@ package Bagger::Storage::PGObject;
  sub foo {
     return $self->call_dbmethod(
         funcname => 'foo',
-	args     => { bar => 'baz' }
+        args     => { bar => 'baz' }
     );
  };
 
@@ -63,19 +63,19 @@ module.
 my $dbh;
 sub _get_dbh() {
    return $dbh if $dbh; # retrieve singleton if available
-   return _new_dbh(); 
+   return _new_dbh();
 }
 
 
 sub _new_dbh() {
    $dbh = DBI->connect(
            "DBI:Pg:" .
-	   "database=" . Bagger::Storage::LenkwerkSetup->lenkwerkdb .
-	   ";host="    . Bagger::Storage::LenkwerkSetup->dbhost .
-	   ";port="    . Bagger::Storage::LenkwerkSetup->dbport, 
-	    Bagger::Storage::LenkwerkSetup->dbuser,
-	    Bagger::Storage::LenkwerkSetup->dbpass,
-	    {AutoCommit => 0 });
+           "database=" . Bagger::Storage::LenkwerkSetup->lenkwerkdb .
+           ";host="    . Bagger::Storage::LenkwerkSetup->dbhost .
+           ";port="    . Bagger::Storage::LenkwerkSetup->dbport,
+           Bagger::Storage::LenkwerkSetup->dbuser,
+           Bagger::Storage::LenkwerkSetup->dbpass,
+           {AutoCommit => 0 });
    return $dbh;
 }
 
@@ -112,3 +112,5 @@ For more information see CPAN docs for the following modules:
 =cut
 
 1;
+
+# vim:ts=4:sw=4:expandtab


### PR DESCRIPTION
Chris used an editor that liberally inserted tabs and spaces, with a tabstop of 8 (apparently?)

I've set a vim modeline (tabstop 4, shiftwidth 4, expandtab) to establish ground rules in all perl files.
I still need to handle SQL and all free text.