### PR TITLE
Fixes #30

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile(
                           'PGObject::Util::DBMethod' => 0,
                           'PGObject::Type::JSON'     => 2.1.1,
                           'URI::Escape'              => 0,
+                          'Capture::Tiny'            => 0,
                          },
     TEST_REQUIRES    => {
                           'Test2::V0'                => 0,


### PR DESCRIPTION
Here we use Capture::Tiny to capture stdout, stderr, and the result of the system calls and WARN anything from STDERR.  This allows us to intercept and log warnings from the application.  We may want to allow warning of STDOUT as well in the future via a package var.

Fixes #30 