### PR TITLE
Dimensions versioning

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,0 +1,30 @@
+#Bagger Configuration
+
+This document lists a full list of Bagger configuration options and their
+relevant values.  Each major component describes the configuration schema and
+each option is documented.
+
+##Storage
+
+This sets up the configuration for storing data on Bagger storage nodes.  It
+is stored in the storage schema on lenkwerk and storage databases.
+
+Here the value is any JSON value (object, array, string, or number) which
+allows great flexibility bur adds some complexity for management.
+
+Storage configuration settings are:
+
+ - production
+    - If this is missing or 0, then index and partitions can be valid into the
+      past.  Schaufel will NOT start in this configuration.
+    
+    - If this is present and 1, then schaufel will start, but partition
+      dimensions can no longer be backdated.  If this is true, then by default
+      imdexes also cannot be backdated, but see `all_backedated_indexes below`.
+ 
+ - allow_backedated_indexes
+    - If absent or 0, then index creation cannot be backdated in production
+    - If present or 1, thn index creation can always be backdated (and
+      backfilled)
+    - See `production` above.
+

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -28,3 +28,13 @@ Storage configuration settings are:
       backfilled)
     - See `production` above.
 
+ - dimensions_hrs_in_future
+    - Defaults to 1
+    - If present, must be a positive integer
+    - How many hours ahead, on production, we future-date partition dimension
+      changes
+
+ - indexes_hrs_in_future
+    - Defaults to 1
+    - If present must be a positive integer
+    - How many hours ahead, on production, we future create index specifications

--- a/lib/Bagger/Storage/Config.pm
+++ b/lib/Bagger/Storage/Config.pm
@@ -103,7 +103,7 @@ sub get {
     my $key = (shift // $self);
     my ($config) = $self->call_procedure(funcname => 'get_config',
                           args => [$key]);
-    return __PACKAGE__->new($config);
+    return $self->new($config) if $config->{key};
 }
 
 =head2 save

--- a/lib/Bagger/Storage/Time_Bound.pm
+++ b/lib/Bagger/Storage/Time_Bound.pm
@@ -90,7 +90,6 @@ coerce 'Bagger::Type::DateTime'
 
 sub _config_dim_timing {
     my $self = shift;
-    use Bagger::Storage::Config;
     my $production = Bagger::Storage::Config->get('production');
     $production = $production->value_string if defined $production;
     my $hours_out;

--- a/lib/Bagger/Storage/Time_Bound.pm
+++ b/lib/Bagger/Storage/Time_Bound.pm
@@ -1,0 +1,171 @@
+=head1
+
+   Bagger::Storage::Time_Bound -- Common Methods for Time Bound DB Objects
+
+=cut
+
+package Bagger::Storage::Time_Bound;
+
+=head1 SYNOPSIS
+
+   package MyClass;
+   use Moose;
+   with 'Bagger::Storage::Time_Bound';
+
+   sub _config_hrs_out { 'MyConfig_in_hours' }
+
+   # then you can
+   #
+   $foo = MyClass->new;
+   $exire_proxy = $foo->_expire_proxy;
+
+=cut
+
+use strict;
+use warnings;
+use Moose::Role;
+use Bagger::Storage::Config;
+use Moose::Util::TypeConstraints;
+use namespace::autoclean;
+
+=head1 DESCRIPTION
+
+Some Bagger entities can be added and need to take effect only in the futre at
+defined points for future partitions.  These include partitioning dimensions,
+indexes, and index fields.  In other words, different indexes can be created or
+retired, and fields can be added or removed, but only for future partitions.
+
+In order to ensure a sane cluster state, we require some time in between the
+change and its impact, with additional checks happening along the
+implementation pathway.  The system is also designed to provide some time for
+human operators to respond to potential issues either by pushing changes out or
+by resolving cluster issues.
+
+=head2 Time-Bound Change Restrictions
+
+The earliest a timebound object may change is at first start of the hour at
+least one hour in the future.  This provides time for the changes to be pushed
+out to the cluster, for monitoring to reconcile the changes, and for human
+operators to find and correct errors if the cluster does not reach a consistent
+state quickly.
+
+Additionally modules can specify a configuration variable which, if set, will
+specify the number of hours out.  This variable MUST be set to a positive
+integer, and this module B<will> throw errors if this is not set.
+
+=head1 REQUIRED INTERFACES
+
+=head2 _config_hours_out
+
+Any C<Time_Bound> Object must have a configuration variable set up to determine
+how far out changes will be applied.
+
+=cut
+
+requires '_config_hours_out';
+
+=head1 ATTRIBUTES
+
+This type has two attributes which are stored as C<Bagger::Type::DateTime> 
+objects.  These objects are coerceable from strings and invoke the standard
+database parsing routines specified by C<Bagger::Type::DateTime> which inherits
+some or all of this functionality from C<PGObject::Type::DateTime>.
+
+=head2 valid_from
+
+This represents the first time the dimension is valid.
+
+In production this dimension is valid at the hour boundary 
+dimensions_hrs_in_future in the future.  When not in production this is valid
+for all time.
+
+=cut
+
+subtype 'Bagger::Type::DateTime'
+=>  as  'Bagger::Type::DateTime';
+
+coerce 'Bagger::Type::DateTime'
+=> from 'Str'
+=> via { Bagger::Type::DateTime->from_db($_) };
+
+sub _config_dim_timing {
+    my $self = shift;
+    use Bagger::Storage::Config;
+    my $production = Bagger::Storage::Config->get('production');
+    $production = $production->value_string if defined $production;
+    my $hours_out;
+    my $in_hrs = Bagger::Storage::Config->get($self->_config_hours_out);
+    $hours_out = $in_hrs->value_string if defined $in_hrs;
+    die 'Production config value invalid' 
+                                       if $production and ($production ne '1');
+    die 'Invalid dimensions_hrs_in_future config variable must be positive int'
+                                    if $hours_out and ($hours_out =~ /\D/);
+    return ($production, $hours_out // 1);
+}
+
+sub _def_valid_from {
+    my $self = shift;
+    my ($production, $hrs_out) = $self->_config_dim_timing;
+    return Bagger::Type::DateTime->inf_past unless $production;
+    return Bagger::Type::DateTime->hour_bound_plus($hrs_out);
+}
+
+
+has valid_from => (is => 'ro', isa => 'Bagger::Type::DateTime', coerce => 1,
+    builder => '_def_valid_from');
+
+=head2 valid_until
+
+This represnets the beginning of the interval the when the dimension is no
+longer valid.
+
+By default, this is valid forever.
+
+To get next expiratoin_date, use the next_expiration_date function.
+
+See C<Bagger::Storage::Time_Bound> for details.
+
+=cut
+
+sub _def_valid_until {
+    return Bagger::Type::DateTime->inf_future;
+}
+
+has valid_until => (is => 'ro', isa => 'Bagger::Type::DateTime', coerce => 1,
+    builder => '_def_valid_until');
+
+=head1 METHODS
+
+=head2 next_expiration_date()
+
+When not in production, returns Past Infinity, because we can back-date
+expirations.
+
+In production, returns the next available dimension change point, namely
+
+the next hour boundary plus dims_in_hrs config variable.
+
+=cut
+
+sub next_expiration_date {
+    my $self = shift;
+    my ($production, $dims_in_hrs) = $self->_config_dim_timing;
+    return Bagger::Type::DateTime->inf_past unless $production;
+    return Bagger::Type::DateTime->hour_bound_plus($dims_in_hrs or 1);
+}
+
+=head1 expire_proxy
+
+Returns a copy of the object with the valid_until replaced with the
+next available expiration time.
+
+This is primarily intended for use in calling ->expire methods.
+
+=cut
+
+sub expire_proxy {
+    my $self = shift;
+    return $self->new(%$self, valid_until => $self->next_expiration_date);
+}
+
+1;

--- a/lib/Bagger/Type/DateTime.pm
+++ b/lib/Bagger/Type/DateTime.pm
@@ -119,7 +119,9 @@ sub hour_bound_plus{
     my ($self, $hours) = @_;
     croak 'Hours must be an int!' if int($hours) ne $hours;
     croak 'Hours must be positive' if $hours < 1;
-    return $self->now->truncate(to => 'hour')->add( hours => (1 + $hours));
+    my $retval =  $self->now->truncate(to => 'hour')->add( hours => (1 + $hours));
+    $retval->{_pgobject_is_tz} = 0;
+    return $retval;
 }
 
 1;

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
@@ -279,6 +279,17 @@ The ordinality of all dimensions equal to or greater than the requested
 ordinality number are incremented.
 $$;
 
+
+CREATE FUNCTION storage.expire_dimension 
+(in_id int, in_valid_until timestamp)
+returns storage.dimensions
+language sql begin atomic
+update storage.dimensions
+   set valid_until = in_valid_until
+ where id = in_id
+RETURNING *;
+END;
+
 -----------------------
 -- Indexes
 -----------------------

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -279,6 +279,17 @@ The ordinality of all dimensions equal to or greater than the requested
 ordinality number are incremented.
 $$;
 
+
+CREATE FUNCTION storage.expire_dimension 
+(in_id int, in_valid_until timestamp)
+returns storage.dimensions
+language sql begin atomic
+update storage.dimensions
+   set valid_until = in_valid_until
+ where id = in_id
+RETURNING *;
+END;
+
 -----------------------
 -- Indexes
 -----------------------

--- a/t/31-config.t
+++ b/t/31-config.t
@@ -15,7 +15,7 @@ db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST}
 db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
 db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
-plan 8;
+plan 9;
 
 # Test data setup
 my $initial_str = 'Nontrivial String {"\u0000"}[]';
@@ -41,3 +41,4 @@ is(pkg()->get($scal_cfg->key)->value_string, $initial_str, 'Initial string retur
 is(pkg()->get($aref_cfg->key)->value, $initial_array, 'Initial aref returned');
 is(pkg()->get($href_cfg->key)->value, $initial_href, 'Initial href returned');
 is(pkg()->get($struct_cfg->key)->value, $initial_struct, 'Struct round trip');
+is(pkg()->get('kfje1432gfds'), undef, 'Unknown key returns undef');

--- a/t/32-dimensions.t
+++ b/t/32-dimensions.t
@@ -1,5 +1,6 @@
 use Test2::V0 -target => { pkg => 'Bagger::Storage::Dimension' , 
-                            db => 'Bagger::Storage::LenkwerkSetup'};
+                            db => 'Bagger::Storage::LenkwerkSetup',
+                           cfg => 'Bagger::Storage::Config'};
 use strict;
 use warnings;
 
@@ -15,7 +16,7 @@ db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST}
 db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
 db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
-plan 14;
+plan 24;
 
 ## test setup
 
@@ -38,3 +39,28 @@ is ( $dim2s->valid_until->to_db, 'infinity', "Valid forever" );
 is ( $dim2s->valid_from->to_db, '-infinity', "Valid from" );
 isa_ok ( $dim2s->valid_from, 'DateTime::Infinite::Past');
 is ( [pkg()->list], [$dim1s, $dim2s], 'Listing provides correct dimensions');
+
+## Expiration and production setup tests.
+
+# setting to Production mode
+
+ok(cfg()->new(key => 'production', value => 1)->save, 'Setting production mode');
+
+ok(my $dim3 = pkg()->new(fieldname => '/baz/1'));
+is($dim3->valid_from, Bagger::Type::DateTime->hour_bound_plus(1), 
+     'Valid_from correct for default values in production');
+is($dim3->valid_until->to_db, 'infinity', 'Valid forever in production');
+is($dim1s->expire->valid_until, Bagger::Type::DateTime->hour_bound_plus(1),
+     'Expiration happens at correct time, default production mode');
+
+ok(cfg()->new(key => 'dimensions_hrs_in_future', value => 3)->save, 
+    'Setting changes to happen 3 hrs in the future');
+
+ok($dim3 = pkg()->new(fieldname => '/baz/1'));
+is($dim3->valid_from, Bagger::Type::DateTime->hour_bound_plus(3),
+    'Valid_from honors dims_hrs_in_future');
+is($dim3->valid_until->to_db, 'infinity', 'Valid forever in production');
+is($dim2s->expire->valid_until, Bagger::Type::DateTime->hour_bound_plus(3),
+     'Expiration honors dims_hrs_in_future');
+
+# expiration


### PR DESCRIPTION
Partially addresses #6
Fixes #35
Fixes #41
    
     This PR adds temporal bounds for partitioning dimensions.  These bounds
     address the fact that we may need to change these and have them take
     effect consistently in the cluster some fixed number of hours out.  The
     future period affects both expirations and new dimensions.
    
     The logic is that if production is set in the config table to 0, we can
     safely backdate changes.  If production is set to 1, we cannot.  We
     then look for the next boundary for partitioning at least one hour out
     (and currently this assumes hourly partitioning, this could change
     after 1.0).  If dimensions_hrs_in_future is set we add that many hours
     instead.
