### PR TITLE
Extension tests

### DIFF
--- a/lib/Bagger/Test/DB/LW.pm
+++ b/lib/Bagger/Test/DB/LW.pm
@@ -1,0 +1,182 @@
+=head1 NAME
+
+   Bagger::Test::PGTap -- Test class for running pgTAP files
+
+=cut
+
+package Bagger::Test::PGTap;
+
+=head1 SYNOPSIS
+
+   skipall => 'pgTap not available' unless Test::PGTap->pgtap_available;
+   Test::PGTap->set_dir('t/sql');
+   # can also set db connection params for psql
+   Test::PGTap->set_psql_params(-U => 'postgres', -p => 5433, -d => 'mydb');
+   # or set dsn
+   Test::PGTap->set_dsn('postgresql://postgres@:5433/mydb');
+   Test::PGTap->run('mytest.pg');
+
+=cut
+use strict;
+use warnings;
+use Carp 'croak';
+use Capture::Tiny;
+
+=head1 FUNCTIONS
+
+=head2 set_psql_params(list)
+
+Sets the parameters for psql.
+
+References may not be passed in.
+
+The arguments are in the order they will be passed to psql.
+
+=cut
+
+my @args;
+
+sub set_psql_params {
+    my $self = shift;
+    my @t_args = @_;
+    unshift @t_args, $self if $self =~ /^-/ || $self !~ /::/ ;
+    for my $a (@t_args) {
+        croak 'No references allowed for arguments' if ref $a;
+    }
+    @args = @t_args;
+}
+
+=head2 set_psql_path
+
+Sets the path to the psql binary if not in the PATH environment
+variable.  Note that the psql binary itself should NOT be part
+of this path.
+
+=cut
+
+my $psql_path;
+
+sub set_psql_path {
+    my $self = shift;
+    $psql_path = shift // $self
+};
+
+=head2 set_dsn
+
+This allows you to set the dsn to use for connecting via psql.
+
+When both dsn and parameters are set, the parameters take precedence.
+
+=cut
+
+my $dsn;
+
+sub set_dsn {
+    my $self = shift;
+    $dsn  = shift // $self;
+}
+
+=head2 set_dir
+
+This sets the directory for the test cases files.
+
+It should not include the file itself.
+
+=cut
+
+my $test_dir;
+
+sub set_dir {
+    my $self = shift;
+    $test_dir = shift // $self;
+}
+
+=head2 pg_tap_available
+
+Checks the available extensions and returns true if pgTAP is available.
+
+Returns false if not.
+
+=cut
+
+sub pg_tap_available{
+    my $self = shift;
+    my $q = "select count(*) from pg_available_extensions() where name = 'pgtap'";
+    my ($stdout, $stderr, $exit) = capture {
+        return system('psql', (scalar @args ? (@args) : ($dsn)),
+            -c => $q, '-t')
+    };
+    warn $stderr if $stderr;
+    return int($stdout);
+}
+
+=head2 run($filename)
+
+This runs a filename specified and prints the output to
+standard output for the test harness.
+
+If params and a dsn are both set, the params take precedence.
+
+=cut
+
+sub params { scalar @args ? (@args) : ($dsn) }
+
+sub run {
+    my $self = shift;
+    my $file = shift // $self;
+    system('psql', params);
+}
+
+=head1 Bagger Initialization for Tests
+
+If we ever try to componentize this, the sections below here have to go.
+
+=head2 init($file)
+
+Sets up and runs file based on standard test boilerplate.
+
+=head2 lw_setup()
+
+Sets up the lenkwerk database parameters
+
+=head2 db
+
+Returns the name of the db setup class
+
+In this case, 'Bagger::Storage::LenkwerkSetup'
+
+=cut
+use Bagger::Storage::LenkwerkSetup;
+sub db { 'Bagger::Storage::LenkwerkSetup' };
+
+sub lw_setup{
+
+    skip_all('BAGGER_TEST_LW environment variable not set') unless defined
+                                                        $ENV{BAGGER_TEST_LW};
+
+    bail_out('BAGGER_TEST_LW_DB environment variable not set') unless defined
+                                                       $ENV{BAGGER_TEST_LW_DB};
+
+
+    db()->set_lenkwerkdb($ENV{BAGGER_TEST_LW_DB});
+    db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST};
+    db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
+    db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
+    __PACKAGE__->set_psql_params(
+        (db()->dbuser ? (-U => db()->dbuser) : ()),
+        (db()->dbhost ? (-h => db()->dbhost) : ()),
+        (db()->dbport ? (-p => db()->dbport) : ()),
+        (db()->lenkwerkdb ? (-d => db()->lenkwerkdb) : ()),
+    );
+}
+
+sub init{
+    my ($self, $file) = @_;
+    lw_setup;
+    __PACKAGE__->run($file);
+}
+
+lw_setup; # always just initialize it for these tests.
+
+1;
+

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
@@ -396,3 +396,11 @@ DO update set value = in_value
 RETURNING *;
 END;
 ---
+
+CREATE PUBLICATION bagger_lw_storage
+FOR TABLE storage.postgres_instance, 
+          storage.indexes, 
+          storage.index_fields, 
+          storage.dimensions, 
+          storage.servermaps, 
+          storage.config;

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -396,3 +396,11 @@ DO update set value = in_value
 RETURNING *;
 END;
 ---
+
+CREATE PUBLICATION bagger_lw_storage
+FOR TABLE storage.postgres_instance, 
+          storage.indexes, 
+          storage.index_fields, 
+          storage.dimensions, 
+          storage.servermaps, 
+          storage.config;

--- a/t/30-dbsetup.t
+++ b/t/30-dbsetup.t
@@ -1,17 +1,7 @@
 use Test2::V0 -target => { pkg => 'Bagger::Storage::LenkwerkSetup' };
+use Bagger::Test::DB::LW;
 use strict;
 use warnings;
-
-skip_all('BAGGER_TEST_LW environment variable not set') unless defined
-                                                        $ENV{BAGGER_TEST_LW};
-
-bail_out('BAGGER_TEST_LW_DB environment variable not set') unless defined
-                                                       $ENV{BAGGER_TEST_LW_DB};
-
-pkg()->set_lenkwerkdb($ENV{BAGGER_TEST_LW_DB});
-pkg()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST};
-pkg()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
-pkg()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
 
 plan 2;

--- a/t/31-lw_storage-objects.t
+++ b/t/31-lw_storage-objects.t
@@ -1,0 +1,4 @@
+use Test2::V0 -target => {db => 'Bagger::Test::DB::LW'};
+
+db()->init('31-lw_storage_objects.pg');
+

--- a/t/41-config.t
+++ b/t/41-config.t
@@ -1,19 +1,8 @@
-use Test2::V0 -target => { pkg => 'Bagger::Storage::Config' , 
-                            db => 'Bagger::Storage::LenkwerkSetup'};
+use Test2::V0 -target => { pkg => 'Bagger::Storage::Config' };
+use Bagger::Test::PGTap;
+use Bagger::Test::DB::LW;
 use strict;
 use warnings;
-
-skip_all('BAGGER_TEST_LW environment variable not set') unless defined
-                                                        $ENV{BAGGER_TEST_LW};
-
-bail_out('BAGGER_TEST_LW_DB environment variable not set') unless defined
-                                                       $ENV{BAGGER_TEST_LW_DB};
-
-
-db()->set_lenkwerkdb($ENV{BAGGER_TEST_LW_DB});
-db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST};
-db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
-db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
 plan 9;
 

--- a/t/42-dimensions.t
+++ b/t/42-dimensions.t
@@ -1,20 +1,8 @@
 use Test2::V0 -target => { pkg => 'Bagger::Storage::Dimension' , 
-                            db => 'Bagger::Storage::LenkwerkSetup',
                            cfg => 'Bagger::Storage::Config'};
+use Bagger::Test::DB::LW;
 use strict;
 use warnings;
-
-skip_all('BAGGER_TEST_LW environment variable not set') unless defined
-                                                        $ENV{BAGGER_TEST_LW};
-
-bail_out('BAGGER_TEST_LW_DB environment variable not set') unless defined
-                                                       $ENV{BAGGER_TEST_LW_DB};
-
-
-db()->set_lenkwerkdb($ENV{BAGGER_TEST_LW_DB});
-db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST};
-db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
-db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
 plan 24;
 

--- a/t/43-index.t
+++ b/t/43-index.t
@@ -1,24 +1,11 @@
 use Test2::V0 -target => {pkg => 'Bagger::Storage::Index',
-                           db => 'Bagger::Storage::LenkwerkSetup',
                           cfg => 'Bagger::Storage::Config',
                            dt => 'Bagger::Type::DateTime',
                           fld => 'Bagger::Storage::Index::Field',
                       };
+use Bagger::Test::DB::LW;
 use strict;
 use warnings;
-use Carp::Always;
-
-skip_all('BAGGER_TEST_LW environment variable not set') unless defined
-                                                        $ENV{BAGGER_TEST_LW};
-
-bail_out('BAGGER_TEST_LW_DB environment variable not set') unless defined
-                                                       $ENV{BAGGER_TEST_LW_DB};
-
-
-db()->set_lenkwerkdb($ENV{BAGGER_TEST_LW_DB});
-db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST};
-db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
-db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
 plan 30;
 

--- a/t/sql/31-lw_storage_objects.pg
+++ b/t/sql/31-lw_storage_objects.pg
@@ -1,0 +1,38 @@
+BEGIN;
+
+set search_path = 'storage';
+CREATE EXTENSION pgtap;
+select plan(14);
+
+select has_table(u)
+  from unnest(array['time_bound'::text, 'postgres_instance', 'indexes',
+                    'index_fields', 'dimensions', 'servermaps', 'config']) u;
+
+
+select set_eq(
+      $$select oid 
+          from pg_class 
+         where relnamespace = 'storage'::regnamespace and relkind in('r', 'S')
+               and relname <> 'time_bound'$$, -- time_bound has no data to dump
+      (select extconfig from pg_extension where extname = 'bagger_lw_storage'),
+      'All tables in the storage schema are set to be dumped'
+);
+
+select has_inherited_tables('storage', 'time_bound', 'Timebound tables exist');
+
+
+select is_ancestor_of('time_bound', u, format('%I is timebound', u))
+from unnest(array['indexes'::text, 'index_fields', 'dimensions']) u;
+
+select set_eq(
+      $$select prrelid::regclass from pg_publication_rel where prpubid in
+               (select oid from pg_publication where pubname = 'bagger_lw_storage')$$,
+      array['postgres_instance'::regclass, 'indexes', 'index_fields', 'dimensions', 
+            'servermaps', 'config'],
+      'All relevant tables are in the relevant publication');
+
+select is((select setting from pg_settings where name = 'wal_level'), 'logical',
+         'WAL level set to logical');
+
+select * from finish();
+ROLLBACK;


### PR DESCRIPTION
Not as pretty as I would like.

The files are built for refactoring more than they are built for perfect code now.

I had trouble with Capture::Tiny, so used more primitive means for capturing output.

Fixes #22.

We can now add more pgTAP tests as well with very little boilerplate.