### PR TITLE
Adding JSONPointer support for Index expressions

### DIFF
--- a/t/43-index.t
+++ b/t/43-index.t
@@ -3,6 +3,7 @@ use Test2::V0 -target => {pkg => 'Bagger::Storage::Index',
                           cfg => 'Bagger::Storage::Config',
                            dt => 'Bagger::Type::DateTime',
                           fld => 'Bagger::Storage::Index::Field',
+                      jsonptr => 'Bagger::Type::JSONPointer',
                       };
 use strict;
 use warnings;
@@ -20,7 +21,7 @@ db()->set_dbhost($ENV{BAGGER_TEST_LW_HOST}) if defined $ENV{BAGGER_TEST_LW_HOST}
 db()->set_dbport($ENV{BAGGER_TEST_LW_PORT}) if defined $ENV{BAGGER_TEST_LW_PORT};
 db()->set_dbuser($ENV{BAGGER_TEST_LW_USER}) if defined $ENV{BAGGER_TEST_LW_USER};
 
-plan 30;
+plan 31;
 
 ### Constructor tests, without index_am
 
@@ -73,7 +74,7 @@ push @{$basic_idx->fields}, fld()->new(
       ordinality => $basic_idx->next_ordinal, expression => fld()->json_field('foo')
 );
 push @{$basic_idx->fields}, fld()->new(
-      ordinality => $basic_idx->next_ordinal, expression => fld()->json_field('bar')
+      ordinality => $basic_idx->next_ordinal, expression => jsonptr()->new('/bar')
 );
 ok($idx = $basic_idx->save, 'Saved idx');
 
@@ -97,3 +98,6 @@ ok($idx = $basic_idx->save, 'Saved idx');
 
 
 is($idx->expire->valid_until, dt()->hour_bound_plus(3), 'Expired to correct hour bound');
+is($fld->from_json_pointer(jsonptr()->new('/foo/bar/1/baz')), 
+   q((((data->'foo')->'bar')->'1')->'baz') , 
+   'JSON Pointer Serialization');


### PR DESCRIPTION
Fixes #8

This automatically converts JSONPointers into nested JSON/JSONB extraction expressions.  It also exposes the functions needed so that they can be composed.

Note that Bagger::Storage::Index::Field is becoming a bit heavy in this regard so I have a new ticket (#57) where I propose breaking these out into something to more easily compose SQL expressions.