### PR TITLE
Procedures to generate servermaps.

### DIFF
--- a/lib/Bagger/Storage/Instance.pm
+++ b/lib/Bagger/Storage/Instance.pm
@@ -201,6 +201,27 @@ sub list {
     return map { __PACKAGE__->new($_) } @results;
 }
 
+=head2 export()
+
+This returns a hashref with the basic information needed for storing host info
+for servermaps etc.
+
+=cut
+
+sub export {
+    my $self = shift;
+    return { id => $self->id, host => $self->host, port => $self->port }
+}
+
+=head2 TO_JSON()
+
+Exports a full copy of the object as a hashref for JSON serialization
+
+=cut
+
+sub TO_JSON { %{$_[0]} }
+
+
 =head1 SEE ALSO
 
 =cut

--- a/lib/Bagger/Storage/Servermap.pm
+++ b/lib/Bagger/Storage/Servermap.pm
@@ -1,0 +1,160 @@
+=head1 NAME
+
+   Bagger::Storage::Servermap -- Servermap generation/persistance in Bagger
+
+=cut
+
+package Bagger::Storage::Servermap;
+
+=head1 SYNOPSIS
+
+    my $servermap = Bagger::Storage::Servermap->most_recent();
+
+    # or to get a specific one
+    #
+    my $servermap = Bagger::Storage::Servermap->get(1);
+
+    # or to generate and save a new one:
+    my $servermap = Bagger::Storage::Servermap->new->save;
+
+=cut
+
+use strict;
+use warnings;
+use Moose;
+use namespace::autoclean;
+use Bagger::Storage::Instance;
+use Bagger::Type::JSON;
+use PGObject::Util::DBMethod;
+use Moose::Util::TypeConstraints;
+with 'Bagger::Storage::PGObject';
+
+Bagger::Type::JSON->register;
+
+=head1 DESCRIPTION
+
+The servermap provides Bagger infrastructure with a general understanding of
+what storage nodes contain copies of which data, and therefore assists in
+both ingestion management and query building.
+
+Unlike more dynamic distributed data environments, Bagger's network data
+distribution is fixed at the point of ingestion.  No provisions for moving
+data around are present.  These are not C<Bagger::Storage::Time_Bound>
+however because they are chaos-sharded and so servermaps do not need to
+respect partition boundaries.
+
+=head1 PROPERTIES
+
+In addition to the typical Time_Bound properties (valid_to, valid_until),
+servermap objects also have the following properties, all of which are optional:
+
+=over
+
+=item id int
+
+This is the database-specified identifier for the record.
+
+=cut
+
+has id => (is => 'ro', isa => 'Int');
+
+=item server_map Bagger::Type::JSON hashref
+
+This contains the actual server map.  It is generated on creation if not
+provided.
+
+=back
+
+=cut
+
+has server_map => (is => 'ro', isa => 'Bagger::Type::JSON',
+                   builder => 'generate_server_map');
+
+=head1 METHODS
+
+The following general methods are used here.  These are also exposed to the 
+user but not always used.
+
+=over
+
+=item generate_server_map
+
+This produces the hash data for the server_map and sets up the serialization to
+JSON.
+
+As of this version, we use a simple circular algorith where a copy of the data
+is stored on a different physical host in a circle.
+
+For version 1, only a replication factor of 2 is supported.
+
+Version 1 of the servermap has a structure as follows
+
+ {
+    host1_port1_id1 => { shaulfel => { host info},
+                         copies   => { [ 
+                                      { primary host info } , 
+                                      { seconary host info }
+                                     ] }
+    ...
+ }
+
+=cut
+
+# Not the most computationally efficient approach but this isn't a frequent
+# task.
+sub generate_server_map {
+    my ($self) = @_;
+    my @hosts = sort { $a->host cmp $b->host } Bagger::Storage::Instance->list;
+    my $first = $hosts[0];
+    my $primaries = [@hosts];
+    # Rotate physical hosts
+    my $secondaries = [(grep { $_->host ne $first->host} @hosts ), 
+                       ( grep { $_->host eq $first->host} @hosts )];
+    my $servmap = { version => 1 };
+    for (@hosts) {
+        my $primary = shift @$primaries;
+        my $secondary = shift @$secondaries;
+        my $keystr = join('_', $primary->host, $primary->port);
+        $servmap->{$keystr} = { schaufel => $primary->export,
+                                copies   => [ $primary->export,
+                                              $secondary->export, ],
+                              }
+    }
+    return Bagger::Type::JSON->new($servmap);
+}
+
+=item save
+
+This method saves the object and returns a new one with the database-specified
+values filled in.
+
+=cut
+
+dbmethod save => (funcname => 'save_servermap', returns_objects => 1);
+
+=item most_recent
+
+Returns the most recent servermap
+
+=cut
+
+dbmethod most_recent => (funcname => 'most_recent_servermap', returns_objects => 1);
+
+=item get($id)
+
+Returns the servermap row by id.
+
+=cut
+
+sub get {
+    my ($class, $id) = @_;
+    return $class->new(
+        ($class->call_procedure(funcname => 'get_servermap', args => [$id]))[0]
+    );
+}
+
+=back
+
+=cut
+
+1;

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
@@ -56,12 +56,12 @@ New states may be added in the future.
 $$;
 
 create table storage.servermaps (
-   generation serial primary key,
+   id serial primary key,
    server_map json not null
 );
 
 SELECT pg_catalog.pg_extension_config_dump('storage.servermaps', '');
-SELECT pg_catalog.pg_extension_config_dump('storage.servermaps_generation_seq', '');
+SELECT pg_catalog.pg_extension_config_dump('storage.servermaps_id_seq', '');
 
 comment on table storage.servermaps is
 $$ The servermaps table stores the server maps by generation so that
@@ -396,6 +396,34 @@ DO update set value = in_value
 RETURNING *;
 END;
 ---
+
+----------------------
+-- Servermaps
+----------------------
+CREATE FUNCTION storage.get_servermap(in_id int)
+returns storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+SELECT * FROM storage.servermaps where id = in_id;
+END;
+
+CREATE FUNCTION storage.most_recent_servermap()
+RETURNS storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+SELECT * FROM storage.servermaps ORDER BY id desc limit 1;
+end;
+
+CREATE FUNCTION storage.save_servermap(in_server_map json)
+RETURNS storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+INSERT INTO storage.servermaps (server_map)
+VALUES (in_server_map)
+RETURNING *;
+END;
+
+COMMENT ON FUNCTION storage.save_servermap(in_server_map json)
+IS
+$$ This function always inserts a new record.$$;
+
+---------------------
+-- Other
+---------------------
 
 CREATE PUBLICATION bagger_lw_storage
 FOR TABLE storage.postgres_instance, 

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -56,12 +56,12 @@ New states may be added in the future.
 $$;
 
 create table storage.servermaps (
-   generation serial primary key,
+   id serial primary key,
    server_map json not null
 );
 
 SELECT pg_catalog.pg_extension_config_dump('storage.servermaps', '');
-SELECT pg_catalog.pg_extension_config_dump('storage.servermaps_generation_seq', '');
+SELECT pg_catalog.pg_extension_config_dump('storage.servermaps_id_seq', '');
 
 comment on table storage.servermaps is
 $$ The servermaps table stores the server maps by generation so that
@@ -396,6 +396,34 @@ DO update set value = in_value
 RETURNING *;
 END;
 ---
+
+----------------------
+-- Servermaps
+----------------------
+CREATE FUNCTION storage.get_servermap(in_id int)
+returns storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+SELECT * FROM storage.servermaps where id = in_id;
+END;
+
+CREATE FUNCTION storage.most_recent_servermap()
+RETURNS storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+SELECT * FROM storage.servermaps ORDER BY id desc limit 1;
+end;
+
+CREATE FUNCTION storage.save_servermap(in_server_map json)
+RETURNS storage.servermaps LANGUAGE SQL BEGIN ATOMIC
+INSERT INTO storage.servermaps (server_map)
+VALUES (in_server_map)
+RETURNING *;
+END;
+
+COMMENT ON FUNCTION storage.save_servermap(in_server_map json)
+IS
+$$ This function always inserts a new record.$$;
+
+---------------------
+-- Other
+---------------------
 
 CREATE PUBLICATION bagger_lw_storage
 FOR TABLE storage.postgres_instance, 

--- a/t/44-instance.t
+++ b/t/44-instance.t
@@ -1,0 +1,26 @@
+use Test2::V0 -target => {inst => 'Bagger::Storage::Instance'};
+use Bagger::Test::DB::LW;
+
+plan(12);
+
+my ($inst1, $inst2);
+
+ok($inst1 = inst()->new(host => 'host1', port => '5433', username => 'bagger'),
+    'Instance 1 created');
+is($inst1->id, undef, 'Id for instance 1 is undef before saving');
+ok($inst1 = $inst1->register(), 'Saved instance 1');
+ok($inst2 = inst()->new(host => 'host2', port => '5433', username => 'bagger'),
+    'Instance 2 created');
+is($inst2->id, undef, 'Id for instance 2 is undef before saving');
+ok($inst2 = $inst2->register());
+
+ok($inst1->id, 'Instance 1 has id after save');
+ok($inst2->id, 'Instance 2 has id after save');
+
+is($inst1->export, {id => $inst1->id, host => 'host1', port => '5433' }, 
+    'inst 1 has correct export');
+is($inst2->export, {id => $inst2->id, host => 'host2', port => '5433' },
+    'inst 2 has correct export');
+
+is(inst()->get($inst1->id), $inst1, 'Instance 1 retrieved');
+is([inst()->list], [$inst1, $inst2], 'List retrieved both instances in order');

--- a/t/45-servermap.t
+++ b/t/45-servermap.t
@@ -1,0 +1,42 @@
+use Test2::V0 -target => {smap => 'Bagger::Storage::Servermap',
+                          inst => 'Bagger::Storage::Instance' };
+use Bagger::Test::DB::LW;
+
+plan(19);
+
+my ($inst1, $inst2, $inst3, $smap);
+
+ok($inst1 = inst()->new(host => 'host1', port => '5433', username => 'bagger'),
+    'Instance 1 created');
+is($inst1->id, undef, 'Id for instance 1 is undef before saving');
+ok($inst1 = $inst1->register(), 'Saved instance 1');
+ok($inst2 = inst()->new(host => 'host2', port => '5433', username => 'bagger'),
+    'Instance 2 created');
+is($inst2->id, undef, 'Id for instance 2 is undef before saving');
+ok($inst2 = $inst2->register());
+ok($inst3 = inst()->new(host => 'host3', port => '5433', username => 'bagger'),
+    'Instance 3 created');
+is($inst3->id, undef, 'Id for instance 3 is undef before saving');
+ok($inst3 = $inst3->register());
+ok($inst1->id, 'Instance 1 has id');
+ok($inst2->id, 'Instance 2 has id');
+ok($inst3->id, 'Instance 3 has id');
+
+ok($smap = smap()->new, 'Created new servermap');
+my $expected_smap =  { host1_5433 => { schaufel =>   $inst1->export,
+                                       copies   => [ $inst1->export, 
+                                                     $inst2->export ], },
+                       host2_5433 => { schaufel =>   $inst2->export,
+                                       copies   => [ $inst2->export,
+                                                     $inst3->export, ], },
+                       host3_5433 => { schaufel =>   $inst3->export,
+                                       copies   => [ $inst3->export,
+                                                     $inst1->export, ], },
+                       version => 1};
+is($smap->server_map, $expected_smap, 'Servermap is correct');
+is($smap->id, undef, 'Servermap id is undefined.');
+ok($smap = $smap->save, 'Saved smap');
+ok($smap->id, 'Servermap now has an id');
+is(smap()->most_recent, $smap, 'get_most_recent returns what we just saved');
+is(smap()->get($smap->id), $smap, 'get by id returns correct smap');
+                      


### PR DESCRIPTION
Fixes #39

The current approach uses rotation to put the first host on the end and rotate the serverhosts in this way.  There are a few cases where this might have unexpected effects.

In the future, we probably need to rotate not by the first host but by a set number detected through an API.  See #61 for further work