### PR TITLE
Moving most methods to declarative mappings

### DIFF
--- a/lib/Bagger/Storage/Config.pm
+++ b/lib/Bagger/Storage/Config.pm
@@ -73,9 +73,6 @@ has key => (is => 'ro', isa => 'Str', required => 1);
 
 =cut
 
-subtype 'Bagger::Type::JSON'
-  => as 'Bagger::Type::JSON';
-
 coerce 'Bagger::Type::JSON'
   => from 'Str | Ref'
   =>  via { Bagger::Type::JSON->new($_) };
@@ -95,6 +92,8 @@ has value => (is      => 'ro',
 =head2 get($key)
 
  Looks up the config item by key and returns it.
+
+ Returns undef if the key was not found.
 
 =cut
 

--- a/lib/Bagger/Storage/Index.pm
+++ b/lib/Bagger/Storage/Index.pm
@@ -27,6 +27,7 @@ use Moose::Util::TypeConstraints;
 use namespace::autoclean;
 use Bagger::Storage::Index::Field;
 use Bagger::Type::DateTime;
+use PGObject::Util::DBMethod;
 use Carp 'croak';
 with 'Bagger::Storage::PGObject', 'Bagger::Storage::Time_Bound';
 
@@ -173,13 +174,9 @@ retrieved.
 
 =cut
 
-sub get {
-    my ($self, $indexname) = @_;
-    return $self->new(
-        $self->call_procedure(funcname => 'get_index',
-                                    args     => [$indexname])
-    );
-};
+
+dbmethod get => (funcname => 'get_index', arg_list => ['indexname'],
+    returns_objects => 1);
 
 =head2 $newindex = $index->save()
 

--- a/lib/Bagger/Storage/Index/Field.pm
+++ b/lib/Bagger/Storage/Index/Field.pm
@@ -174,13 +174,8 @@ Returns a list of index fields for the given index id.
 
 =cut
 
-sub list {
-    my ($self, $index_id) = @_;
-    return map { $self->new($_) }
-          $self->call_procedure(funcname => 'get_index_fields',
-                                    args => [$index_id]);
-
-}
+dbmethod list => (funcname => 'get_index_fields', arg_list => ['index_id'], 
+    returns_objects => 1);
 
 =head2 save
 

--- a/lib/Bagger/Storage/Instance.pm
+++ b/lib/Bagger/Storage/Instance.pm
@@ -154,12 +154,8 @@ Returns the db instance by id.
 
 =cut
 
-sub get {
-    my ($self, $id) = @_;
-    my ($result) = __PACKAGE__->call_procedure(
-                     funcname => 'get_pg_instance_by_id', args => [$id]);
-    return __PACKAGE__->new($result);
-}
+dbmethod get => (funcname => 'get_pg_instance_by_id', arg_list => ['id'],
+    returns_objects => 1);
 
 =head2 get_by_info($host, $port)
 
@@ -167,14 +163,8 @@ Returns the db instance by hostname and port.
 
 =cut
 
-sub get_by_info {
-    my ($self, $host, $port) = @_;
-    my ($result) = __PACKAGE__->call_procedure(
-                     funcname => 'get_pg_instance_by_host_and_port',
-                     args     => [$host, $port]
-    );
-    return __PACKAGE__->new($result);
-}
+dbmethod get_by_info => (funcname => 'get_pg_instance_by_host_and_port',
+    arg_list => ['host', 'port'], returns_objects => 1);
 
 =head2 set_status($status)
 
@@ -182,12 +172,8 @@ This sets the instance status and returns a new object.
 
 =cut
 
-sub set_status {
-    my ($self, $status) = @_;
-    my ($result) = $self->call_dbmethod(funcname => 'set_pg_instance_status',
-            args => {status => $status});
-    return __PACKAGE__->new($result);
-}
+dbmethod set_status => (funcname => 'set_pg_instance_status',
+    arg_list => ['status'], returns_objects => 1);
 
 =head2 list()
 
@@ -195,11 +181,7 @@ This returns a list of instances, set up as objects from the database.
 
 =cut
 
-sub list {
-    my ($self) = @_;
-    my @results = $self->call_dbmethod(funcname => 'list_pg_instances');
-    return map { __PACKAGE__->new($_) } @results;
-}
+dbmethod list => (funcname => 'list_pg_instances', returns_objects => 1);
 
 =head2 export()
 

--- a/lib/Bagger/Storage/Servermap.pm
+++ b/lib/Bagger/Storage/Servermap.pm
@@ -146,12 +146,7 @@ Returns the servermap row by id.
 
 =cut
 
-sub get {
-    my ($class, $id) = @_;
-    return $class->new(
-        ($class->call_procedure(funcname => 'get_servermap', args => [$id]))[0]
-    );
-}
+dbmethod get => (funcname => 'get_servermap', arg_list => ['id'], returns_objects => 1);
 
 =back
 

--- a/lib/Bagger/Type/JSON.pm
+++ b/lib/Bagger/Type/JSON.pm
@@ -6,9 +6,13 @@
 
 package Bagger::Type::JSON;
 use parent 'PGObject::Type::JSON';
+use Moose::Util::TypeConstraints;
 use strict;
 use warnings;
 use Carp 'croak';
+
+subtype __PACKAGE__
+ => as  __PACKAGE__;
 
 =head1 SYNOPSIS
 

--- a/t/41-config.t
+++ b/t/41-config.t
@@ -1,5 +1,4 @@
 use Test2::V0 -target => { pkg => 'Bagger::Storage::Config' };
-use Bagger::Test::PGTap;
 use Bagger::Test::DB::LW;
 use strict;
 use warnings;

--- a/t/43-index.t
+++ b/t/43-index.t
@@ -4,6 +4,7 @@ use Test2::V0 -target => {pkg => 'Bagger::Storage::Index',
                           fld => 'Bagger::Storage::Index::Field',
                       jsonptr => 'Bagger::Type::JSONPointer',
                       };
+use Carp::Always;
 use Bagger::Test::DB::LW;
 use strict;
 use warnings;

--- a/t/45-servermap.t
+++ b/t/45-servermap.t
@@ -1,6 +1,7 @@
 use Test2::V0 -target => {smap => 'Bagger::Storage::Servermap',
                           inst => 'Bagger::Storage::Instance' };
 use Bagger::Test::DB::LW;
+use Carp::Always;
 
 plan(19);
 


### PR DESCRIPTION
This apparently has been supported in PGObject::Util::DBMethod but either I had forgotten when I added it or Erik added it.  This allows us to write simpler clode for more cases, and declare methods more easily.

Fixes #64