### PR TITLE
Autodetect number of hosts to rotate servermap

### DIFF
--- a/lib/Bagger/Storage/Servermap.pm
+++ b/lib/Bagger/Storage/Servermap.pm
@@ -105,11 +105,16 @@ Version 1 of the servermap has a structure as follows
 sub generate_server_map {
     my ($self) = @_;
     my @hosts = sort { $a->host cmp $b->host } Bagger::Storage::Instance->list;
+    my $rotate = $self->call_procedure(funcname => 'servermap_rotate_num');
+    ($rotate) = values %$rotate; 
     my $first = $hosts[0];
     my $primaries = [@hosts];
+    my $secondaries = [@hosts]; # independent copies
     # Rotate physical hosts
-    my $secondaries = [(grep { $_->host ne $first->host} @hosts ), 
-                       ( grep { $_->host eq $first->host} @hosts )];
+    for (1 .. $rotate){
+        my $s = shift @$secondaries;
+        push @$secondaries, $s;
+    }
     my $servmap = { version => 1 };
     for (@hosts) {
         my $primary = shift @$primaries;

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
@@ -417,6 +417,12 @@ VALUES (in_server_map)
 RETURNING *;
 END;
 
+CREATE FUNCTION storage.servermap_rotate_num()
+RETURNS int language sql begin atomic
+SELECT count(*) from storage.postgres_instance
+group by host order by 1 desc limit 1;
+end;
+
 COMMENT ON FUNCTION storage.save_servermap(in_server_map json)
 IS
 $$ This function always inserts a new record.$$;

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -417,6 +417,12 @@ VALUES (in_server_map)
 RETURNING *;
 END;
 
+CREATE FUNCTION storage.servermap_rotate_num()
+RETURNS int language sql begin atomic
+SELECT count(*) from storage.postgres_instance
+group by host order by 1 desc limit 1;
+end;
+
 COMMENT ON FUNCTION storage.save_servermap(in_server_map json)
 IS
 $$ This function always inserts a new record.$$;

--- a/t/41-config.t
+++ b/t/41-config.t
@@ -1,5 +1,4 @@
 use Test2::V0 -target => { pkg => 'Bagger::Storage::Config' };
-use Bagger::Test::PGTap;
 use Bagger::Test::DB::LW;
 use strict;
 use warnings;


### PR DESCRIPTION
This fixes #61.  If there are a number of Bagger instances on the same host in the middle of the list, we will detect and rotate accordingly.

The new logic is to rotate by the maximum number of bagger instances hosted on the same physical host.  In the case where someone has more than half running on the same host, then some failure tolerance will be lost, but that's their fault.  I suppose if it becomes critical we can detect and warn in that case, but I doubt it will be a serious problem at scale.