### PR TITLE
Makefile improvements for the extension

### DIFF
--- a/sql/lenkwerk/storage/Makefile
+++ b/sql/lenkwerk/storage/Makefile
@@ -1,5 +1,12 @@
 EXTENSION = bagger_lw_storage
+EXTVERSION = 0.0.1
 DATA = $(wildcard sql/*--*.sql)
-PG_CONFIG = pg_config
+DATA_built = sql/$(EXTENSION)--$(EXTVERSION).sql
+PG_CONFIG := pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
+	cp $< $@
+$(EXTENSION).control: $(EXTENSION).control.in
+	sed 's/EXTVERSION/$(EXTVERSION)/;s/EXTENSION/$(EXTENSION)/;s/EXTCOMMENT/$(EXTCOMMENT)/' $< > $@

--- a/sql/lenkwerk/storage/bagger_lw_storage.control.in
+++ b/sql/lenkwerk/storage/bagger_lw_storage.control.in
@@ -1,4 +1,4 @@
 comment = 'The Bagger Lenkwerk Storage Schema'
-default_version = '0.0.1'
+default_version = 'EXTVERSION'
 relocatable = false
 


### PR DESCRIPTION
1.  Version information is only in the Makefile.
2.  Primary SQL file gets generated on make
3.  Contro file gets generated by make

Improves our general positioning regarding using extensions for Bagger going forward in the future.  Fixes #49