### PR TITLE
Storage agent part 2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,8 @@ WriteMakefile(
                           'AnyEvent'                        => 0,
                           'Coro'                            => 0,
                           'JSON'                            => 0,
+                          'Parse::RecDescent'               => 0,
+                          'Sys::Hostname'                   => 0,
                           # Mostly core dependencies shipping with Perl
                           'Coro::AnyEvent'                  => 0,
                           'AnyEvent::Loop'                  => 0,

--- a/bin/storage_agent
+++ b/bin/storage_agent
@@ -1,0 +1,5 @@
+#!/usr/bin/env perl
+
+use Bagger::CLI;
+
+run_program('Bagger::Agent::Storage');

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,6 +41,10 @@ Storage configuration settings are:
     - If present must be a positive integer
     - How many hours ahead, on production, we future create index specifications
 
+ - bagger_db
+    - defaults to bagger
+    - Name of database on storage nodes.
+
 ### Table Management
 
  - data_storage_mode

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,10 +1,10 @@
-#Bagger Configuration
+# Bagger Configuration
 
 This document lists a full list of Bagger configuration options and their
 relevant values.  Each major component describes the configuration schema and
 each option is documented.
 
-##Storage
+## Storage
 
 This sets up the configuration for storing data on Bagger storage nodes.  It
 is stored in the storage schema on lenkwerk and storage databases.
@@ -13,6 +13,8 @@ Here the value is any JSON value (object, array, string, or number) which
 allows great flexibility bur adds some complexity for management.
 
 Storage configuration settings are:
+
+### Temporal Management
 
  - production
     - If this is missing or 0, then index and partitions can be valid into the
@@ -39,7 +41,23 @@ Storage configuration settings are:
     - If present must be a positive integer
     - How many hours ahead, on production, we future create index specifications
 
+### Table Management
+
  - data_storage_mode
     - The storage mode of the data column for the main data tables.
       When the table is created, this will be used to ALTER TABLE and set the
       storage mode for the column
+
+### Schaufel Management
+
+ - kafka_topic
+    - The Kafka topic we are to load data from
+
+ - kafka_broker
+    - The broker host for Kafka
+
+ - schaufel_threads
+   -  How many threads to use to load data from Kafka via Schaufel
+
+ - kafka_consumer_group
+   -  The consumer group to join

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -45,6 +45,12 @@ Storage configuration settings are:
     - defaults to bagger
     - Name of database on storage nodes.
 
+ - retain_hrs
+    - defaults to 24
+    - Number of hours to retain inbound data.
+    - 0 disables purging of old data.
+
+
 ### Table Management
 
  - data_storage_mode

--- a/lib/Bagger/Agent/Storage.pm
+++ b/lib/Bagger/Agent/Storage.pm
@@ -255,6 +255,7 @@ sub start {
         #
         # Step 1:  Find our instance
         write_config() if $genconfig;
+    }
     if (!$hostname) {
         # fallback:  inifile, then Sys::Hostname::hostname
         $hostname = (defined $Bagger::CLI::ini{instance}{host}) ?

--- a/lib/Bagger/Agent/Storage.pm
+++ b/lib/Bagger/Agent/Storage.pm
@@ -1,0 +1,331 @@
+=head1 NAME
+
+   Bagger::Agent::Storage -- Storage Agent for Bagger
+
+=cut
+
+package Bagger::Agent::Storage;
+
+=head1 SYNOPSIS
+
+   Bagger::Agent::Storage->run
+
+   # or alternative;y (usually used in testing)
+
+   Bagger::Agent::Storage->start
+   Bagger::Agent::Storage->loop
+
+   # to stop
+   
+   Bagger::Agent::Storage->stop
+
+   # also can write config:
+
+   Bagger::Agent::Storage->write_config
+
+=cut
+
+use strict;
+use warnings;
+use AnyEvent;
+use Coro;
+use AnyEvent::Loop;
+use Net::Etcd;
+use Getopt::Long;
+use Config::IniFiles;
+use Sys::Hostname;
+use Bagger::Storage::Config;
+use Bagger::Storage::Instance;
+
+=head1 DESCRIPTION
+
+This module provides the routines for the agents which run on the storage nodes
+which are responsible for listening ot events and processing them.
+
+Bagger uses a distributed configuration store, such as Etcd or Zookeeper for
+node configuration, but the point of truth is the lenkwerk PostgreSQL database.
+These configuration stores are effectively points of notification and
+publication of changes, and the Lenkwerk agent listens to these events and
+publishes them to the event store.
+
+The storage agents connect to the Lenkwerk databases in order to retrive the
+initial configuration store information and then disconnect.  They may
+reconnect if they need to register state, such a node going down.  Nodes going
+down, however, are registered on a best effort basis.  Therefore schaufel
+instances and their associated agents must handle the case where the node is
+down but the system still believes it is up.
+
+Bagger operates under the general assumption that critical structural changes
+to the data semantics stored will take place at a point in the future at an
+hour boundary.  These changes do not necessarily require a restart of Schaufel
+instances.  Servermap changes do require a restart of schaufel instances but
+they do not require a new schema just because the servermap changes.
+
+In future versions the agent may publish statistics to the key/value store or
+via other ways.  This is not implemented at present however.
+
+If a Schaufel has crashed erroneously, the correct way to restart it is to
+restart the agent.  If the node is listed as having a read-only or offline
+status, then changing this in Lenkwerk should cause the agent to start
+schaufel.
+
+=head1 PROGRAM CONTROL FUNCTIONS
+
+The program control functions provide handles on running the actual agent.
+
+The primary way this is usually run is with the C<run()> package method.  For
+testing, C<start()> can be called folloed by C<loop()>.  When it is time to
+stop the loop, you can call stop.
+
+=head2 run
+
+The C<run()> function starts the agent and then enters the loop() function.
+
+=cut
+
+# Just a dispatch table
+my %prefix_proc = (
+    PostgresInstance => \&postgres_instance,
+    Index            => \&write_data,
+    Dimension        => \&write_data,
+    Config           => \&write_data,
+    Servermap        => \&update_servermap,
+);
+
+sub run {
+    start();
+    loop();
+}
+
+# callback for messages from the key/value store:
+
+sub _process_kvmsg {
+    my ($key, $value) = @_;
+    for my $k (%prefix_proc) {
+        goto $prefix_proc{$k} if $key =~ m#^/$k#;
+    }
+}
+
+=head2 start
+
+This routine starts the agent.  This includes setting up the waters on etcd and
+appropriate callbacks for various types of events.  These are then processed one
+at a time as they are received.
+
+=cut
+
+# Using module-local variables for the singular state of the running instance.
+# These represent all the constant data needed for handling events.  They should
+# ONLY be set by start().
+my ($hostname, $instanceport, $connect_role, $instance, $retention, $servermap,
+    $kvstore, $genconfig);
+
+sub _add_opts {
+    return (
+        'instancehost|H=s' => \$hostname,
+        'instanceport|P=i' => \$instanceport,
+        'baggerdbuser|B=s' => \$connect_role,
+        'genconfig|g=s'      => \$genconfig,
+    );
+}
+
+sub start {
+    # get config
+    # Bagger::CLI already sets up our db info
+    #
+    # Step 1:  Find our instance
+    write_config() if $genconfig;
+
+    if (!$hostname) {
+        # fallback:  inifile, then Sys::Hostname::hostname
+        $hostname = (defined $Bagger::CLI::ini{instance}{host}) ?
+             $Bagger::CLI::ini{instance}{host} : hostname;
+    }
+    if(!$instanceport) {
+        # fallback: inifile, then if there is only one port rgistered
+        # on host
+        $instanceport = (defined $Bagger::CLI::ini{instance}{port} ?
+             $Bagger::CLI::ini{instance}{port} : undef);
+    }
+
+    # At this point we can assume we have a hostname.  We can NOT assume we
+    # have a port.
+
+    if ($instanceport) {
+        $instance = Bagger::Storage::Instance->get_by_info($hostname, $instanceport);
+    } else {
+        my @instancelist = rep {$_->host eq $hostname} Bagger::Storage::Instance->list;
+        if (scalar @instancelist > 1) {
+            die "Was not assigned a port and there are multiple instances for $hostname";
+        }
+        ($instance) = @instancelist;
+    }
+    die "No instance for hostname $hostname" unless $instance;
+
+    $servermap = Bagger::Storage::Servermap->most_recent;
+    die 'No servermap set yet' unless $servermap;
+
+    my $kvstore_type = Bagger::Storage::Config->get('kvstore_type');
+    my $kvstore_config = Bagger::Storage::Config->get('kvstore_config');
+    $kvstore = Bagger::Agent::KVStore->new($kvstore_type, $kvstore_config);
+
+    # enforce_retention to set up next callback
+    enforce_retention();
+    # set up watches on kvstore
+    $kvstore->watch(\&_process_kvmsg);
+    return;
+}
+
+=head2 loop
+
+Enters the main application loop.
+
+=cut
+
+# AnyEvent::Loop::run just advances one_event at a time in an endless loop.
+# So here we just set a global state variable and stop when it is set.
+my $stop = 0;
+sub loop {
+    AnyEvent::Loop::one_event while (not $stop);
+}
+
+=head2 stop
+
+Stops the event loop and exits
+
+=cut
+
+sub stop {
+    $stop = 1;
+}
+
+=head1 EVENT PROCESSING
+
+Event decisions are based on prefixes on etcd keys.  The following prefixes
+require the following actions:
+
+=over
+
+=item /PostresInstance
+
+May require starting or stopping Schaufel if the instance in quesiton is used
+by our schaufel.
+
+=item /Index
+
+Write new data to the storage node
+
+=item /Dimension
+
+Write new data to the storage node
+
+=item /Servermap
+
+Write new data to the storage node and restart Schaufel
+
+=item /Config
+
+Write new data to the storage node.
+
+=back
+
+=head1 EVENT HANDLER FUNCTIONS
+
+=head2 write_data
+
+Used to write the data from Etcd to the storage node.
+
+=cut
+
+sub write_data {
+    my ($key, $value) = $_;
+    # Write data to local instance
+    # need to write row, thinking of just passing the json to populate_record.
+}
+
+=head2 postgres_instance
+
+Checks to see whether our instance is affected and if so, starts or stops
+schaufel.
+
+=cut
+
+sub postgres_instance{
+    my ($key, $value) = @_;
+    write_data($key, $value);
+    # Need to see if it is us or one of our copies
+    # Handle state appropriately
+}
+
+=head2 update_servermap
+
+Writes the data to the storage node, writes a new Schaufel config, and
+restarts Schaufel.
+
+=cut
+
+sub update_servermap{
+    my ($key, $value) = @_;
+    write_data($key, $value);
+    write_schaufel_config();
+    restart_schaufel();
+}
+
+=head1 AGENT FUNCTION CHANGES
+
+=head2 write_config
+
+Writes our own bootstrapping configuration file and exit.
+
+The file to write is specified by the -g or --genconfig flag.  This means you
+can specify -c for a config file to read and -g for a file to write,
+overwriting options in the commandline.  This can be useful for bootstrapping
+a configuration for the storage node.
+
+=cut
+
+# We use the tied hash API here so hash assignments are write operations.
+# Note that autovification does not work on tied hashes so to create a new
+# section we have to explicitly initiate it as a new hashref before we can
+# assign values to the section.
+
+sub write_conifig{
+    tie my %inifile, 'Config::IniFiles', ( -file => $genconfig );
+    $inifile{lenkwerk} = {}; # new section, no autovivification
+    $inifile{lenkserk}{host}     = Bagger::Storage::LenkwerkSetup->dbhost;
+    $inifile{lenkserk}{port}     = Bagger::Storage::LenkwerkSetup->dbport;
+    $inifile{lenkserk}{username} = Bagger::Storage::LenkwerkSetup->dbuser;
+    $inifile{instance} = {}; # new section, no autovivification
+    $inifile{instance}{host}     = $hostname;
+    $inifile{instance}{port}     = $instanceport;
+    exit(0);
+}
+
+=head2 write_schaufel_config
+
+Writes the schaufel config based on the servermap
+
+=cut
+
+sub write_schaufel_config{}
+
+=head2 restart_schaufel
+
+Restarts Schaufel
+
+=cut
+
+sub restart_schaufel{}
+
+=head2 enforce_retention
+
+This handles the retention strategy by processing the partition list and
+dropping expired tables.
+
+=cut
+
+sub enforce_retention{
+    AnyEvent->timer(after => 3600, cb => \&enforce_retention);
+}
+
+1;

--- a/lib/Bagger/Agent/Storage.pm
+++ b/lib/Bagger/Agent/Storage.pm
@@ -118,7 +118,7 @@ at a time as they are received.
 # These represent all the constant data needed for handling events.  They should
 # ONLY be set by start().
 my ($hostname, $instanceport, $connect_role, $instance, $retention, $servermap,
-    $kvstore, $genconfig, @copies);
+    $kvstore, $genconfig);
 
 sub _add_opts {
     return (
@@ -137,10 +137,11 @@ sub _add_opts {
 sub _my_smap_key { join('_', $instance->host, $instance->port) };
 
 sub start {
+    # get config
+    # Bagger::CLI already sets up our db info
     #
     # Step 1:  Find our instance
     write_config() if $genconfig;
-
 
     if (!$hostname) {
         # fallback:  inifile, then Sys::Hostname::hostname

--- a/lib/Bagger/Agent/Storage.pm
+++ b/lib/Bagger/Agent/Storage.pm
@@ -256,11 +256,14 @@ sub start {
         # Step 1:  Find our instance
         write_config() if $genconfig;
     }
+    # another perl critic false positive
+    ## no critic qw(Variables::ProhibitPackageVars)
     if (!$hostname) {
         # fallback:  inifile, then Sys::Hostname::hostname
         $hostname = (defined $Bagger::CLI::ini{instance}{host}) ?
              $Bagger::CLI::ini{instance}{host} : hostname;
     }
+    ## use critic
     if ($instanceport) {
         # even if we got an instance we should validate it and reload it.
         $instance = Bagger::Storage::Instance->get_by_info($hostname, $instanceport);
@@ -483,6 +486,7 @@ sub _all_copies_can_write {
 }
 
 
+## no critic qw(ControlStructures::ProhibitCascadingIfElse ValuesAndExpressions::ProhibitMixedBooleanOperators)
 sub postgres_instance{
     my ($key, $value) = @_;
     write_data($key, $value);
@@ -498,6 +502,7 @@ sub postgres_instance{
         }
     }
 }
+## use critic
 
 =head2 update_servermap
 

--- a/lib/Bagger/Agent/Storage.pm
+++ b/lib/Bagger/Agent/Storage.pm
@@ -247,28 +247,21 @@ sub _cond_start_schaufel {
 }
 
 sub start {
-    # get config
-    # Bagger::CLI already sets up our db info
-    #
-    # Step 1:  Find our instance
-    write_config() if $genconfig;
-
+    $instance = shift;
+    if ($instance) {
+        $hostname = $instance->host;
+        $instanceport = $instance->port;
+    } else {
+        #
+        # Step 1:  Find our instance
+        write_config() if $genconfig;
     if (!$hostname) {
         # fallback:  inifile, then Sys::Hostname::hostname
         $hostname = (defined $Bagger::CLI::ini{instance}{host}) ?
              $Bagger::CLI::ini{instance}{host} : hostname;
     }
-    if(!$instanceport) {
-        # fallback: inifile, then if there is only one port rgistered
-        # on host
-        $instanceport = (defined $Bagger::CLI::ini{instance}{port} ?
-             $Bagger::CLI::ini{instance}{port} : undef);
-    }
-
-    # At this point we can assume we have a hostname.  We can NOT assume we
-    # have a port.
-
     if ($instanceport) {
+        # even if we got an instance we should validate it and reload it.
         $instance = Bagger::Storage::Instance->get_by_info($hostname, $instanceport);
     } else {
         my @instancelist = rep {$_->host eq $hostname} Bagger::Storage::Instance->list;

--- a/lib/Bagger/Agent/Storage/Mapper.pm
+++ b/lib/Bagger/Agent/Storage/Mapper.pm
@@ -29,7 +29,7 @@ use strict;
 use warnings;
 use Exporter 'import';
 use Scalar::Util 'blessed';
-our @EXPORT_OK = qw(kval_key pg_object);
+our @EXPORT_OK = qw(kval_key pg_object key_to_relname);
 
 =head1 DESCRIPTION
 
@@ -140,8 +140,8 @@ table name or a blessed object passed in the first spot, and if not, then a hash
 
 Examples:
 
-    kval_key('postgres_instances', {host => 'host1',
-                                    port => 5432,
+    kval_key('postgres_instance', {host => 'host1', 
+                                    port => 5432, 
                                 username => 'bagger',
                                   status => 0 })
     #returns '/PostgresInstance/host1/5432'

--- a/lib/Bagger/Agent/Storage/Mapper.pm
+++ b/lib/Bagger/Agent/Storage/Mapper.pm
@@ -158,4 +158,19 @@ sub kval_key {
     return $keygen{$class}($val) if defined $keygen{$class};
 }
 
+=head2 key_to_relname ($key)
+
+Returns the relation name used by the key.  This allows a sort of logical
+replication to be built between the KVStore and the storage node's Postgresql
+instances.
+
+=cut
+
+sub key_to_relname {
+    my ($key) = @_;
+    my $class = pg_object($key);
+    return unless $class;
+    return $classmap{$class};
+}
+
 1;

--- a/lib/Bagger/Agent/Storage/Message.pm
+++ b/lib/Bagger/Agent/Storage/Message.pm
@@ -1,0 +1,79 @@
+=head1 NAME
+
+    Bagger::Agent::Storage::Message -- Inbound Message Handler of Storage Agent
+
+=cut
+
+package Bagger::Agent::Storage::Message;
+
+=head1 SYNOPSIS
+
+    my $msg = Bagger::Agent::Storage::Message->new(
+        instance => $instance, key => $key, value = $value);
+    $msg->save;
+
+=cut
+
+use strict;
+use warnings;
+use Moose;
+use namespace::autoclean;
+use Bagger::Agent::Storage::Mapper;
+use PGObject::Util::DBMethod;
+with 'Bagger::Agent::Storage::PGObject';
+
+=head1 DESCRIPTION
+
+This module provides the basic routines for handling KVStore serialized JSON to
+the storage node's own configuration store.  This module is intended to allow a
+sort of logical replication from the kvstore of choice into the PostgreSQL
+relations used for configuration.  The mechanism is designed to work solely for
+Bagger's internal use.
+
+=head1 ATTRIBUTES
+
+=head2 instance (required)
+
+This is brought in via the Bagger::Agent::Storage::PGObject role and provides a
+starting point for the interfaces which allow us to write this data to the
+storage nodes.
+
+=head2 key (string, required)
+
+This required attribute is the string sent as the key for the kvstore
+implementation.
+
+=cut
+
+has key => (is => 'ro', isa => 'Str', required => 1);
+
+=head2 value (string, required)
+
+This required attribute is the JSON received from the kvstore as JSON.
+
+=cut
+
+has value => (is => 'ro', isa => 'Str', required => 1);
+
+=head2 relname (lazy, string0
+
+This is calculated based on the key.  It is used to tell PostgreSQL where to
+save the data.
+
+=cut
+
+sub _build_relname { Bagger::Agent::Storage::Mapper::relname_from_ley($_[0]->key) };
+
+has relname => (is => 'ro', isa => 'lazy');
+
+=head1 METHODS
+
+=head2 save
+
+Writes this to the storage node.
+
+=cut
+
+dbmethod save => (funcname => 'inbound_from_kvstore');
+
+__PACKAGE__->meta->make_immutable;

--- a/lib/Bagger/Agent/Storage/Message.pm
+++ b/lib/Bagger/Agent/Storage/Message.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use Moose;
 use namespace::autoclean;
-use Bagger::Agent::Storage::Mapper;
+use Bagger::Agent::Storage::Mapper 'key_to_relname';
 use PGObject::Util::DBMethod;
 with 'Bagger::Agent::Storage::PGObject';
 
@@ -62,9 +62,9 @@ save the data.
 
 =cut
 
-sub _build_relname { Bagger::Agent::Storage::Mapper::relname_from_ley($_[0]->key) };
+sub _build_relname { key_to_relname($_[0]->key) };
 
-has relname => (is => 'ro', isa => 'lazy');
+has relname => (is => 'ro', lazy => 1, builder => '_build_relname');
 
 =head1 METHODS
 
@@ -75,5 +75,7 @@ Writes this to the storage node.
 =cut
 
 dbmethod save => (funcname => 'inbound_from_kvstore');
+before save => sub { $_[0]->relname };
+after save => sub { $_[0]->_dbh->commit}; # needed for visibility.
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Bagger/Agent/Storage/PGObject.pm
+++ b/lib/Bagger/Agent/Storage/PGObject.pm
@@ -38,8 +38,15 @@ of the connection.
 
 =cut
 
-has instance => (is => 'ro', isa => 'Bagger::Storage::PGObject');
+has instance => (is => 'ro', isa => 'Bagger::Storage::PGObject', required => 1);
 
-sub _get_dbh { $_[0]->instance->cnx }
-
+sub _get_dbh { 
+    my ($self) = @_;
+    my $dbh = $self->instance->cnx;
+    $dbh->do(q(set session_replication_role = 'replica')) 
+        unless ($dbh->{replication});
+    $dbh->do(q(set search_path = 'storage')) unless ($dbh->{replication});
+    $dbh->{replication} = 1;
+    return $dbh;
+}
 1;

--- a/lib/Bagger/Agent/Storage/PGObject.pm
+++ b/lib/Bagger/Agent/Storage/PGObject.pm
@@ -1,0 +1,45 @@
+=head1 NAME
+
+    Bagger::Agent::Storage::PGObject -- The PGObject mapper for inbound messages
+
+=cut
+
+package Bagger::Agent::Storage::PGObject;
+
+=head1 SYNOPSIS
+
+    package Bagger::Agent::Storage::Message;
+    use Moose;
+    with 'Bagger::Agent::Storage::PGObject';
+
+=cut
+
+use strict;
+use warnings;
+use Moose::Role;
+with 'Bagger::Storage::PGObject';
+
+=head1 DESCRIPTION
+
+This PGObject role provides a role for accessing the B<storage> note's lenkwerk
+database schema.  This shares most functionality with the
+C<Bagger::Storage::PGObject> module, but uses a connection to the storage db
+instead.
+
+=head1 REQUIRED ATTRIBUTES
+
+=head2 instance
+
+Must be of  a C<Bagger::Storage::Instance> type.  This is the source of the
+database connection.
+
+Now, we can always assume that this database connection is valid for the life
+of the connection.
+
+=cut
+
+has instance => (is => 'ro', isa => 'Bagger::Storage::PGObject');
+
+sub _get_dbh { $_[0]->instance->cnx }
+
+1;

--- a/lib/Bagger/Agent/Storage/Schaufel.pm
+++ b/lib/Bagger/Agent/Storage/Schaufel.pm
@@ -1,0 +1,174 @@
+=head1 NAME
+
+    Bagger::Agent::Storage::Schaufel -- Schaufel Control Routines for Bagger
+
+=cut
+
+package Bagger::Agent::Storage::Schaufel;
+
+=head1 SYNOPSIS
+
+    my $scaufel_handle = Bagger::Agent::Storage::Schaufel->new(
+        cmd     => $schaufel_cmd, log     => $schaufel_log, 
+        hosts   => @instances,    broker  => $kafka_broker,
+        topic   => $kafka_topic,  group   => $kafka_consumer_group,
+        threads => $schaufel_threads,
+    );
+    $schaufel->start;
+    $schaufel->stop; # returns exit code and self-destructs
+
+    # to stop with a specific signal (default is TERM):
+    $schaufel->stop('INT');
+
+=cut
+
+use strict;
+use warnings;
+use Moose;
+use Moose::Util::TypeConstraints;
+use namespace::autoclean;
+
+=head1 DESCRIPTION
+
+This module provides the general control functionalty for Schaufel for loading
+data into Bagger.
+
+A Schaufel object here represents a single Schaufel process from the preloading
+through termination.  Once the process is terminated, the object is destroyed.
+
+=head1 ATTRIBUTES
+
+=head2 cmd Str
+
+This is the command used to run Schaufel.  It defaults to C</usr/bin/schaufel>
+
+=cut
+
+has cmd => (is => 'ro', isa => 'Str', default => '/usr/bin/schaufel');
+
+=head2 log Str
+
+This is the log file where the Schaufel process should log.
+
+It defaults to C</var/log/schaufel/bagger.log>.
+
+=cut
+
+has log => (is => 'ro', isa => 'Str', default => '/var/log/schaufel/bagger.log');
+
+=head2 hosts ArrayRef[Bagger::Storage::Instance], Required
+
+This is an ARRAYREF of two Bagger::Storage::Instance types, though this may
+change in future versions to be more accommodating for different replication
+factors etc.
+
+=cut
+
+has hosts => (is => 'ro', isa => 'ArrayRef[Bagger::Storage::Instance]', required => 1);
+
+=head2 broker Str, required
+
+This is the location of the Kafka broker
+
+=cut
+
+has broker => (is => 'ro', isa => 'Str', required => 1);
+
+=head2 topic Str, required
+
+This is the name of the Kafka topic
+
+=cut
+
+has topic => (is => 'ro', isa => 'Str', required => 1);
+
+=head2 group Str, required
+
+This is the ID of the kafka consumer grou.
+
+=cut
+
+has group => (is => 'ro', isa => 'Str', required => 1);
+
+=head2 threads, Int, default 1
+
+This is the number of threads to use for loading data.  Defaults to 1
+
+=cut
+
+has threads => (is => 'ro', isa => 'Int', default => 1);
+
+=head2 args (generated)
+
+These are the arguments to be passed to Schaufel
+
+=cut
+
+sub _build_args {
+    my $self = shift;
+    # Host_string is a comma separated list of host:port identifiers
+    
+    my $host_string = join ',',
+                       map { join(':', $_->host, $_->port) }
+                      @{$self->hosts};
+    my @schaufel_args = (
+        -l => $self->log,     -i => 'k',          -b => $self->broker,
+        -g => $self->group,   -o => 'p',          -t => $self->topic,
+        -p => $self->threads, -H => $host_string,
+    );
+    return \@schaufel_args;
+}
+
+
+
+has args => (is   => 'ro', isa      => 'ArrayRef[Str]', 
+             lazy => 1,     builder => '_build_args');
+
+=head2 pid (set on start)
+
+This is the process id of the actual schaufel child process.  It represents
+a handle for signals intended to cause the process to terminate or to watch
+for its termination.
+
+=cut
+
+has pid => (is => 'rw', isa => 'Int', writer => '_set_pid');
+
+=head1 METHODS
+
+=head1 start
+
+This starts the schaufel process and returns $self->pid.
+
+=cut
+
+sub start {
+    my $self = (@_);
+    my $pid = fork;
+
+    # if parent process set the pid and return
+    if ($pid) {
+        $self->_set_pid($pid);
+        return $pid;
+    }
+
+    exec($self->cmd, @{$self->args}); # safe since we always have more than one
+    exit; # just to tell Perl we know we will exit after
+}
+
+=head1 stop($sig),
+
+Stops the process.  The status is intended to be handled by the listener.
+
+$sig, the signal to use, is optional and defaults to TERM.
+
+=cut
+
+sub stop {
+    my ($self, $sig) = @_;
+    $sig //= 'TERM';
+    kill $sig, $self->pid;
+    undef $self;
+}
+
+__PACKAGE__->meta->make_immutable;

--- a/lib/Bagger/Agent/Storage/Schaufel.pm
+++ b/lib/Bagger/Agent/Storage/Schaufel.pm
@@ -8,7 +8,7 @@ package Bagger::Agent::Storage::Schaufel;
 
 =head1 SYNOPSIS
 
-    my $scaufel_handle = Bagger::Agent::Storage::Schaufel->new(
+    my $schaufel = Bagger::Agent::Storage::Schaufel->new(
         cmd     => $schaufel_cmd, log     => $schaufel_log, 
         hosts   => @instances,    broker  => $kafka_broker,
         topic   => $kafka_topic,  group   => $kafka_consumer_group,

--- a/lib/Bagger/Agent/Storage/Schaufel.pm
+++ b/lib/Bagger/Agent/Storage/Schaufel.pm
@@ -111,11 +111,14 @@ sub _build_args {
     my $host_string = join ',',
                        map { join(':', $_->host, $_->port) }
                       @{$self->hosts};
+    # False positive for perl critic
+    ## no critic qw(InputOutput::ProhibitInteractiveTest)
     my @schaufel_args = (
         -l => $self->log,     -i => 'k',          -b => $self->broker,
         -g => $self->group,   -o => 'p',          -t => $self->topic,
         -p => $self->threads, -H => $host_string,
     );
+    ## use critic
     return \@schaufel_args;
 }
 

--- a/lib/Bagger/Agent/Storage/Schaufel.pm
+++ b/lib/Bagger/Agent/Storage/Schaufel.pm
@@ -130,9 +130,11 @@ This is the process id of the actual schaufel child process.  It represents
 a handle for signals intended to cause the process to terminate or to watch
 for its termination.
 
+A value of 0 means the process has been stopped.
+
 =cut
 
-has pid => (is => 'rw', isa => 'Int', writer => '_set_pid');
+has pid => (is => 'ro', isa => 'Int', writer => '_set_pid');
 
 =head1 METHODS
 
@@ -143,7 +145,7 @@ This starts the schaufel process and returns $self->pid.
 =cut
 
 sub start {
-    my $self = (@_);
+    my ($self) = @_;
     my $pid = fork;
 
     # if parent process set the pid and return
@@ -168,7 +170,7 @@ sub stop {
     my ($self, $sig) = @_;
     $sig //= 'TERM';
     kill $sig, $self->pid;
-    undef $self;
+    $self->_set_pid(0);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Bagger/CLI.pm
+++ b/lib/Bagger/CLI.pm
@@ -110,7 +110,6 @@ our %ini;
 
 sub run_program {
     my ($class, $noargs) = @_;
-    my @add_opts = $class->_add_opts() if UNIVERSAL::can($class, '_add_opts');
     ## no critic qw(BuiltinFunctions::ProhibitStringyEval)
     eval "require $class" or die $@;
     $class->import if $class->can('import');

--- a/lib/Bagger/CLI.pm
+++ b/lib/Bagger/CLI.pm
@@ -104,11 +104,18 @@ function called.
 
 =cut
 
+## no critic qw(Variables::ProhibitPackageVars)
 our %ini;
+## use critic
 
 sub run_program {
     my ($class, $noargs) = @_;
     my @add_opts = $class->_add_opts() if UNIVERSAL::can($class, '_add_opts');
+    ## no critic qw(BuiltinFunctions::ProhibitStringyEval)
+    eval "require $class" or die $@;
+    $class->import if $class->can('import');
+    my @add_opts;
+    @add_opts = $class->_add_opts() if $class->can('_add_opts');
     my ($host, $port, $username, $dbname, $configfile);
     unless ($noargs) {
         GetOptions (
@@ -132,9 +139,6 @@ sub run_program {
     Bagger::Storage::LenkwerkSetup->set_dbport($port) if $port;
     Bagger::Storage::LenkwerkSetup->set_lenkwerkdb($dbname) if $dbname;
     Bagger::Storage::LenkwerkSetup->set_dbuser($username) if $username;
-    ## no critic qw(BuiltinFunctions::ProhibitStringyEval)
-    eval "require $class" or die $@;
-    $class->import if $class->can('import');
     $class->run;
 }
 
@@ -149,7 +153,6 @@ sub config_file {
     my ($host, $port, $username, $dbname);
     if ($configfile) {
         no autovivification;
-        my %ini;
         tie %ini, 'Config::IniFiles', ( -file => $configfile );
         $host     = $ini{lenkwerk}{host}     if exists $ini{lenkwerk}{host};
         $port     = $ini{lenkwerk}{port}     if exists $ini{lenkwerk}{port};

--- a/lib/Bagger/CLI.pm
+++ b/lib/Bagger/CLI.pm
@@ -104,8 +104,11 @@ function called.
 
 =cut
 
+our %ini;
+
 sub run_program {
     my ($class, $noargs) = @_;
+    my @add_opts = $class->_add_opts() if UNIVERSAL::can($class, '_add_opts');
     my ($host, $port, $username, $dbname, $configfile);
     unless ($noargs) {
         GetOptions (
@@ -114,11 +117,11 @@ sub run_program {
             "username|U=s" => \$username,
             "database|d=s" => \$dbname,
             "config|c=s"   => \$configfile,
+            @add_opts,
         );
     }
     if ($configfile) {
         no autovivification;
-        my %ini;
         tie %ini, 'Config::IniFiles', ( -file => $configfile );
         $host     = $ini{lenkwerk}{host}     if exists $ini{lenkwerk}{host};
         $port     = $ini{lenkwerk}{port}     if exists $ini{lenkwerk}{port};
@@ -158,5 +161,25 @@ sub config_file {
     Bagger::Storage::LenkwerkSetup->set_lenkwerkdb($dbname) if $dbname;
     Bagger::Storage::LenkwerkSetup->set_dbuser($username) if $username;
 }
+
+=head1 WRITING BAGGER PROGRAMS
+
+There are a number of things which the Bagger CLI supports which require
+
+=head2 Extending Configuration
+
+There are two important methods for extending configuration supported by
+C<Bagger::CLI>.  The first is that additional directives can be placed in the
+inifile whose result has a global scope.  If an inifile has been used, the
+handler is at C<%Bagger::CLI::ini>.  Additional configuration variables can be
+accessed using C<Config::IniFile>'s tied hash API.
+
+The second method, usually used in tandem is to specify an C<_add_opts> in the
+main application class of your program.  This MUST return a list with an
+even-numbered list of elements.  These get passed along to the C<GetOptions>
+call.  Since you would usually pass along references to "my"-scoped variables
+in your module, these would get written there.
+
+=cut
 
 1;

--- a/lib/Bagger/Storage/Instance.pm
+++ b/lib/Bagger/Storage/Instance.pm
@@ -139,11 +139,13 @@ interacting with the storage nodes.
 
 sub _build_cnx {
     my $self = shift;
-    return DBI->connect("dbi:Pg:host=" . $self->host . ";port=" . $self->port,
-        $self->username, , { AutoCommit => 0, RaiseError => 1 });
+    my $dbname = Bagger::Storage::Config->get('bagger_db')->value_string;
+    return DBI->connect("dbi:Pg:host=" . $self->host . ";port=" . $self->port .
+        ";dbname=" . ($dbname // 'bagger'),
+        $self->username, undef, { AutoCommit => 0, RaiseError => 1 });
 }
 
-has cnx => (is => 'ro', lazy => 1, builder => '_build_cnx');
+has cnx => (is => 'ro', lazy => 1, builder => '_build_cnx', isa => 'DBI::db');
 
 =head1 METHODS
 

--- a/lib/Bagger/Storage/Instance.pm
+++ b/lib/Bagger/Storage/Instance.pm
@@ -130,6 +130,21 @@ sub _can_write {
     return bool($self->status & F_WRITE);
 }
 
+=head2 cnx
+
+This is a database connection to the host instance itself.  It is used for
+interacting with the storage nodes.
+
+=cut
+
+sub _build_cnx {
+    my $self = shift;
+    return DBI->connect("dbi:Pg:host=" . $self->host . ";port=" . $self->port,
+        $self->username, , { AutoCommit => 0, RaiseError => 1 });
+}
+
+has cnx => (is => 'ro', lazy => 1, builder => '_build_cnx');
+
 =head1 METHODS
 
 =head2 register

--- a/lib/Bagger/Storage/PGObject.pm
+++ b/lib/Bagger/Storage/PGObject.pm
@@ -63,7 +63,7 @@ module.
 {
 my $dbh;
 sub _get_dbh() {
-   return $dbh if $dbh; # retrieve singleton if available
+   return $dbh if $dbh and ($dbh->ping); # retrieve singleton if connected
    return _new_dbh();
 }
 

--- a/lib/Bagger/Storage/PGObject.pm
+++ b/lib/Bagger/Storage/PGObject.pm
@@ -43,7 +43,6 @@ use PGObject;
 use Try::Tiny;
 use DBI;
 use Bagger::Storage::LenkwerkSetup;
-
 with 'PGObject::Simple::Role';
 
 our $VERSION = '0.0.1';

--- a/lib/Bagger/Storage/Servermap.pm
+++ b/lib/Bagger/Storage/Servermap.pm
@@ -88,8 +88,8 @@ For version 1, only a replication factor of 2 is supported.
 Version 1 of the servermap has a structure as follows
 
  {
-    host1_port1_id1 => { shaulfel => { host info},
-                         copies   => { [
+    host1_port1 => { shaulfel => { host info},
+                     copies   => { [
                                       { primary host info } ,
                                       { seconary host info }
                                      ] }

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage--0.0.1.sql
@@ -428,6 +428,25 @@ IS
 $$ This function always inserts a new record.$$;
 
 ---------------------
+-- Inbound from kvstore
+---------------------
+
+CREATE FUNCTION storage.inbound_from_kvstore
+(in_relname regclass, in_value json)
+returns void
+language plpgsql
+as
+$$
+begin
+    -- Note that regclass as a type does escaping during stringification
+    execute format(
+        'INSERT INTO %s SELECT * from json_populate_record(NULL::%s, $1)',
+        in_relname, in_relname) using in_value;
+
+end;
+$$;
+
+---------------------
 -- Other
 ---------------------
 

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -428,6 +428,26 @@ IS
 $$ This function always inserts a new record.$$;
 
 ---------------------
+-- Inbound from kvstore
+---------------------
+
+CREATE FUNCTION storage.inbound_from_kvstore
+(in_relname regclass, in_value json)
+returns void
+language plpgsql
+as
+$$
+begin
+    -- Note that regclass as a type does escaping during stringification
+    execute format(
+        'INSERT INTO %s SELECT json_populate_recordset(NULL::$s, $2)',
+        relname, relname) using data;
+    RETURN;
+
+end;
+$$;
+
+---------------------
 -- Other
 ---------------------
 

--- a/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
+++ b/sql/lenkwerk/storage/sql/bagger_lw_storage.sql
@@ -440,9 +440,8 @@ $$
 begin
     -- Note that regclass as a type does escaping during stringification
     execute format(
-        'INSERT INTO %s SELECT json_populate_recordset(NULL::$s, $2)',
-        relname, relname) using data;
-    RETURN;
+        'INSERT INTO %s SELECT * from json_populate_record(NULL::%s, $1)',
+        in_relname, in_relname) using in_value;
 
 end;
 $$;

--- a/t/12-kvstore-keygen.t
+++ b/t/12-kvstore-keygen.t
@@ -5,10 +5,10 @@ use Test2::V0 -target => { inst => 'Bagger::Storage::Instance',
                            dim  => 'Bagger::Storage::Dimension',
                            idx  => 'Bagger::Storage::Index',
                            fld  => 'Bagger::Storage::Index::Field'};
-use Bagger::Agent::Storage::Mapper qw(kval_key pg_object);
+use Bagger::Agent::Storage::Mapper qw(kval_key pg_object key_to_relname);
 use strict;
 use warnings;
-plan 15;
+plan 20;
 
 is(pg_object('/Servermap'), smap(), 'Servermap object determined');
 is(pg_object('/PostgresInstance/host1/5432'), inst(), 'PG Instance key read');
@@ -17,22 +17,29 @@ is(pg_object('/Dimension/1'), dim(), 'Dimension key found');
 is(pg_object('/Index/1/1'), fld(), 'Index Field Found');
 is(pg_object('/Index/1'), idx(), 'Index found');
 
+# Relname from key
+is(key_to_relname('/PostgresInstance/host1/5432'), 'postgres_instance');
+is(key_to_relname('/Servermap'), 'servermap');
+is(key_to_relname('/Dimension/1'), 'dimension');
+is(key_to_relname('/Index/1/1'), 'index_field');
+is(key_to_relname('/Index/1'), 'index');
+
 # Table types
 is(kval_key('postgres_instance', {host => 'host1', port => '5432'}),
         '/PostgresInstance/host1/5432',
         'kval_key for postgres_instance record');
 
 is(kval_key('servermap', {id => 1}), '/Servermap',
-       'kval_key for servermaps record');
+       'kval_key for servermap record');
 
 is(kval_key('dimension', {id => 1}), '/Dimension/1',
-       'kval_key for dimensions record');
+       'kval_key for dimension record');
 
 is(kval_key('index', {id => 1}), '/Index/1',
-       'kval_key for indexes record');
+       'kval_key for index record');
 
 is(kval_key('index_field', {id => 1, index_id => 2}), '/Index/2/1',
-        'kval_key for index_fields record');
+        'kval_key for index_field record');
 
 ## Object types
 is(kval_key(inst()->new(host => 'host1', port => 5432, 

--- a/t/14-schaufel.t
+++ b/t/14-schaufel.t
@@ -1,0 +1,72 @@
+use Test2::V0 -target => {proc => 'Bagger::Agent::Storage::Schaufel',
+                          inst => 'Bagger::Storage::Instance' };
+use AnyEvent; # needed to test exit handling
+use AnyEvent::Loop;
+
+# Constructor tests
+plan 13;
+my $proc;
+my $hosts = [ inst()->new(host => 'foo', port => 5432, username => 'test'),
+              inst()->new(host => 'bar', port => 5432, username => 'test') ];
+
+ok($proc = proc()->new(
+        broker => 'test',  threads => 2, hosts => $hosts,
+        topic  => 'test1', group   => 'test'
+    ), 'Created initial Schaufel object');
+
+is($proc->pid, undef, 'Pid is not defined after created');
+is($proc->log, '/var/log/schaufel/bagger.log', 'Default log correct');
+is($proc->cmd, '/usr/bin/schaufel', 'Default command correct');
+is($proc->args, [
+        -l => $proc->log,     -i => 'k',          -b => 'test',
+        -g => 'test',         -o => 'p',          -t => 'test1',
+        -p => 2,              -H => 'foo:5432,bar:5432' ],
+    'Default args correct');
+
+# start/stop tests
+ok(my $sleep = proc()->new(
+        broker => 'test',  threads => 2,      hosts => $hosts,
+        topic  => 'test1', group   => 'test', args  => ['30'],
+        cmd    => 'sleep'
+    ), 'Created sleeper process handle');
+
+# sentinel handler for capturing SIGCHILD Signals
+# This particular listener will never get triggered but it
+# sets up infrastructure needed to guarantee capture of child
+# exit events
+
+my $w = AnyEvent->child(pid => $$, cb => sub {} );
+
+$sleep->start;
+ok(my $pid = $sleep->pid, 'Got a pid now');
+$w = AnyEvent->child(pid => $sleep->pid, cb => sub {
+     pass('Sleep process stopped');
+     is($_[0], $pid, 'Got pid back from sleep');
+     is($_[1], 15, 'Exit status 15') # but note, schaufel masks signals
+                                     # and returns 0
+ } );
+$sleep->stop;
+AnyEvent::Loop::one_event();
+is($sleep->pid, 0, 'Sleep is now undef');
+ok($sleep, 'Sleep still an object');
+
+# Exit Handling Tests
+
+ok(my $false = proc()->new(
+        broker => 'test',  threads => 2,      hosts => $hosts,
+        topic  => 'test1', group   => 'test', args  => ['30'],
+        cmd    => 'false'
+    ), 'Created sleeper process handle');
+
+my $run = 1;
+$false->start;
+$pid = $false->pid;
+$w = AnyEvent->child(pid => $false->pid, cb => sub {
+     pass('False process stopped');
+     is($_[0], $pid, 'Got pid back from sleep');
+     ok($_[1], 'Non-zero exit status');
+     $run = 0;
+ } );
+
+AnyEvent::Loop::one_event() while $run;
+

--- a/t/46-inbound_messages.t
+++ b/t/46-inbound_messages.t
@@ -1,0 +1,49 @@
+use Test2::V0 -target => { msg => 'Bagger::Agent::Storage::Message', 
+                           ins => 'Bagger::Storage::Instance', 
+                           cfg => 'Bagger::Storage::Config', 
+                           dim => 'Bagger::Storage::Dimension',
+                           idx => 'Bagger::Storage::Index',
+                           fld => 'Bagger::Storage::Index::Field',
+                           ldb => 'Bagger::Storage::LenkwerkSetup'};
+use Bagger::Test::DB::LW;
+
+
+plan 15;
+
+cfg()->new(key => 'bagger_db', value => ldb()->lenkwerkdb)->save;
+
+my $dbh = ins()->_get_dbh;
+my $sth = $dbh->prepare(q(select setting from pg_settings where name = 'unix_socket_directories'));
+$sth->execute;
+my ($dirlist) = $sth->fetchrow_array();
+my ($path) = split /,/, $dirlist;
+
+### setup tests
+ok(my $inst = ins()->new(
+        host => ldb()->dbhost // $path , port => ldb()->dbport, username => ldb()->dbuser
+    ), 'Created an instance to connect to db');
+
+ok($inst->cnx, 'Instance can connect to the db');
+
+ok($inst->cnx->ping, 'Pinged the db');
+
+### Insert and retrieval tests
+ok(my $msg = msg()->new(instance => $inst,
+        key => '/PostgresInstance/foo/5432',
+        value => '{"host": "foo", "port": 5432, "username": "bagger", "id": 100, "status": 0}',
+    ), 'New message for new instance 100');
+is($msg->relname, 'postgres_instance');
+ok($inst->cnx->ping, 'still connected to db');
+ok($msg->_dbh->ping, 'DB connection working');
+ok($msg->save, 'Saved instance message');
+ok(my $var = ins()->get_by_info('foo', '5432'), 'Retrieved my instance');
+is($var->id, 100, 'Got back correct instance id');
+ok($msg = msg()->new(instance => $inst,
+        key => '/Dimension/100',
+        value => '{"id": 100, "valid_from": "-infinity", "valid_until": "infinity", 
+        "ordinality": 0, "fieldname": "foo", "default_val": "none"}'
+    ), 'Created Dimension Message');
+ok($msg->save, 'Saved dimension message');
+ok(($var) = dim()->list, 'Got dimension back');
+is($var->ordinality, 0, 'Ordinality set correctly');
+is($var->id, 100, 'Ordinality set correctly');


### PR DESCRIPTION
Fixes #17 
Fixes #31 
Fixes #95 

This is the second piece of the storage agent.  It involves some refactoring to encapsulate some important logic in the Schaufel process, and provides full Schaufel process control as well as data retention enforcement.

This agent constitutes a general event loop watching for Schaufel's exit, as well as arrival of new data from the kvstore system.

This is intended to be reviewed after #102, but the two could be reviewed together if people find that easier.  It is not marked as ready for review yet because tests have not been added but review of form, idea, etc, is welcome at this stage.