### PR TITLE
Makefile.PL: add sqlfluff as linter and formatter

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,15 @@
+;https://docs.sqlfluff.com/en/stable/configuration.html
+;https://docs.sqlfluff.com/en/stable/rules.html#ruleref
+[sqlfluff]
+dialect=postgres
+sql_file_exts=.sql
+max_line_length=80
+
+[sqlfluff:indentation]
+allow_implicit_indents = true
+
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = upper

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use strict;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
@@ -29,5 +30,17 @@ WriteMakefile(
                           'File::Find'               => 0,
                         },
 );
+
+sub MY::postamble {
+return <<"MAKE_EOF";
+.PHONY: lint
+sql-lint:
+\tsqlfluff lint
+
+.PHONY: sql-fmt
+sql-fmt:
+\tsqlfluff format
+MAKE_EOF
+}
 
 # vim:ts=4:sw=4:expandtab


### PR DESCRIPTION
I've added custom make targets to `Makefile.pl`. These are `sql-lint` and `sql-fmt`, both calling sqlfluff with `.sqlfluff` as a config.

See this PR here to get an ebuild: https://github.com/onemoredata/bagger-overlay/pull/2

The only problem I've encountered is that function definitions need to be reworked to use dollar quoted strings (and this seems to break PGObject, as far I can see). I will have to look for a workaround here. We may discuss linting specifics after we agreed to this.