### PR TITLE
Making LW Tests ids independent from rest of test suite

### DIFF
--- a/lib/Bagger/Agent/LW.pm
+++ b/lib/Bagger/Agent/LW.pm
@@ -115,7 +115,7 @@ sub start {
              _run_injection('before_kvwrite', $key, $value) if $inject;
              my $resp = $kvstore->write($key, $value);
              undef $guard if $resp; # processing complete
-             _run_injection('after_kvwrite', $resp) if $inject;
+             _run_injection('after_kvwrite', $resp, $key) if $inject;
          } else {
              # message not of interest, can undef the guard
              undef $guard;


### PR DESCRIPTION
One issue with existing PRs and the LW agent tests  issue is that because of relying on internal Postgres id sequences, the ids of the tests can change, causing false positive failures.  This patch corrects these problems.  It is needed by #115, #102, and #105