### PR TITLE
Fixing SQL Makefile

### DIFF
--- a/sql/lenkwerk/storage/Makefile
+++ b/sql/lenkwerk/storage/Makefile
@@ -1,7 +1,6 @@
 EXTENSION = bagger_lw_storage
 EXTVERSION = 0.0.1
 DATA = $(wildcard sql/*--*.sql)
-DATA_built = sql/$(EXTENSION)--$(EXTVERSION).sql
 PG_CONFIG := pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
Before it was trying to double-install the main extension file.  This was because of the overlap of DATA and DATA_built which are additive. Removing the DATA_built has resolved this problem.

Fixes #119