### PR TITLE
Fixing test cases

### DIFF
--- a/sql/ingestion/trigger/src/jsonptr_unescape.c
+++ b/sql/ingestion/trigger/src/jsonptr_unescape.c
@@ -35,19 +35,19 @@ jsonptr_unescape(char *escaped, char *buff) {
         *buff = '\0';
         maxlen = strlen(escaped);
         len = 0;
-        pos = escaped; // generates warning
+        pos = escaped; 
 
         // null byte ends check
         while ((*pos != '\0') && (len <= maxlen)) {
             bpos = buff + len;
             c = *pos;
             if (c == '~'){ /* escaping logic */
-                if (*(pos +1) == '0') {
-                    chr = '~';
+                if (*(pos + 1) == '0') {
+                    c = '~';
                     ++pos;
                 }
                 else if (*(pos + 1) == '1') {
-                    chr = '/';
+                    c = '/';
                     ++pos;
                 }
             }


### PR DESCRIPTION
This fixes an issue with escape characters always resolving to ~ because of wrong variable being used.